### PR TITLE
Handle fork failure for all user-space applications.

### DIFF
--- a/src/user/applications/TUI/Terminal.cc
+++ b/src/user/applications/TUI/Terminal.cc
@@ -106,6 +106,10 @@ bool Terminal::initialise()
     if (pid == -1)
     {
         syslog(LOG_INFO, "TUI: Couldn't fork: %s", strerror(errno));
+        DirtyRectangle rect;
+        write("Couldn't fork: ", rect);
+        write(strerror(errno), rect);
+        redrawAll(rect);
         return false;
     }
     else if (pid == 0)

--- a/src/user/applications/TUI/Terminal.cc
+++ b/src/user/applications/TUI/Terminal.cc
@@ -103,7 +103,12 @@ bool Terminal::initialise()
 
     // Fire up a shell session.
     int pid = m_Pid = fork();
-    if (pid == 0)
+    if (pid == -1)
+    {
+        syslog(LOG_INFO, "TUI: Couldn't fork: %s", strerror(errno));
+        return false;
+    }
+    else if (pid == 0)
     {
         close(0);
         close(1);

--- a/src/user/applications/init/main.c
+++ b/src/user/applications/init/main.c
@@ -46,6 +46,11 @@ extern int ts();
 void start(const char *proc)
 {
   pid_t f = fork();
+  if(f == -1)
+  {
+    syslog(LOG_ALERT, "init: fork failed %s", strerror(errno));
+    exit(errno);
+  }
   if(f == 0)
   {
     syslog(LOG_INFO, "init: starting %s...", proc);

--- a/src/user/applications/ipc-test-server/main.cc
+++ b/src/user/applications/ipc-test-server/main.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -31,7 +30,12 @@ int main(int argc, char *argv[])
     printf("IPC Test: Server, daemonising\n");
 
     pid_t id = fork();
-    if(!id)
+    if (id == -1)
+    {
+        printf("Forking failed.");
+        return 1;
+    }
+    else if(id == 0)
     {
         // Grab an endpoint to use.
         createEndpoint("ipc-test");

--- a/src/user/applications/login/login.c
+++ b/src/user/applications/login/login.c
@@ -233,7 +233,14 @@ int main(int argc, char **argv)
 
       // Logged in successfully - launch the shell.
       int pid;
-      if ( (g_RunningPid=pid=fork()) == 0)
+      pid = g_RunningPid = fork();
+
+      if (pid == -1)
+      {
+        printf("Fork failed %s\n", strerror(errno));
+        exit(errno);
+      }
+      else if (pid == 0)
       {
         // Child...
         g_RunningPid = -1;

--- a/src/user/applications/sudo/main.c
+++ b/src/user/applications/sudo/main.c
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -109,8 +108,13 @@ int main(int argc, char *argv[])
     if(iRunShell)
     {
         // Execute root's shell
-        int pid;
-        if((pid = fork()) == 0)
+        int pid = fork();
+        if(pid == -1)
+        {
+            fprintf(stderr, "sudo: couldn't fork: %s\n", strerror(errno));
+            exit(errno);
+        }
+        else if(pid == 0)
         {
             // Run the command
             execlp(pw->pw_shell, pw->pw_shell, 0);
@@ -136,8 +140,13 @@ int main(int argc, char *argv[])
     else
     {
         // Run the command
-        int pid;
-        if((pid = fork()) == 0)
+        int pid = fork();
+        if(pid == -1)
+        {
+            fprintf(stderr, "sudo: couldn't fork: %s\n", strerror(errno));
+            exit(errno);
+        }
+        else if(pid == 0)
         {
             // Run the command
             execvp(argv[nStart], &argv[nStart]);

--- a/src/user/applications/syscall-test/syscall-test.c
+++ b/src/user/applications/syscall-test/syscall-test.c
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -41,6 +40,7 @@ int test_open(void)
   else
   {
     printf("FAIL - errno %d (%s)\n", errno, strerror(errno));
+    return FAIL;
   }
 
   printf ("\tOpen nonexistant file - ");
@@ -53,6 +53,7 @@ int test_open(void)
   else
   {
     printf ("FAIL - errno %d (%s)\n", errno, strerror(errno));
+    return FAIL;
   }
 
   printf ("\tCreate file - ");
@@ -65,6 +66,7 @@ int test_open(void)
   else
   {
     printf("FAIL - errno %d (%s)\n", errno, strerror(errno));
+    return FAIL;
   }
 
   printf("\tRecycle descriptors - ");
@@ -79,10 +81,19 @@ int test_open(void)
   else
   {
     printf("FAIL - %d, %d\n", fd4, fd5);
+    return FAIL;
   }
 
   int hahaha = open("/applications/bash", O_RDWR);
-  if(fork() == 0)
+  pid_t pid = fork();
+
+  if(pid == -1)
+  {
+      printf("FAIL - fork failed\n");
+      return FAIL;
+  }
+
+  if(pid == 0)
   {
       close(hahaha);
       int rofl = open("/applications/bash", O_RDWR);
@@ -111,7 +122,8 @@ int main (int argc, char **argv)
   printf("optind: %d\n", optind);
   printf ("Syscall test starting...\n");
 
-  test_open ();
-  return 0;
-
+  if (test_open() == PASS)
+      return EXIT_SUCCESS;
+  else
+      return EXIT_FAILURE;
 }

--- a/src/user/applications/ttyterm/ttyterm.cc
+++ b/src/user/applications/ttyterm/ttyterm.cc
@@ -255,7 +255,12 @@ int main(int argc, char **argv)
 
     // Start up child process.
     g_RunningPid = fork();
-    if(g_RunningPid == 0)
+    if(g_RunningPid == -1)
+    {
+        syslog(LOG_ALERT, "ttyterm: couldn't fork: %s", strerror(errno));
+        return EXIT_FAILURE;
+    }
+    else if(g_RunningPid == 0)
     {
         close(0);
         close(1);


### PR DESCRIPTION
syscall-test now also uses the FAIL define, and checks the result of test_open().
