### PR TITLE
Use include-what-you-use to help simplify the dependency tree

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -560,6 +560,8 @@ if env['iwyu']:
     env['iwyu'] += ' -Xiwyu --no_default_mappings'
     env['iwyu'] += ' -Xiwyu --transitive_includes_only'
 
+    env.MergeFlags('-w')  # Compiler warnings are not helpful in IWYU.
+
     env['CXXFLAGS'] = env['CFLAGS'] = []
 
     env['CC'] = env['iwyu']

--- a/src/modules/drivers/common/ata/BusMasterIde.cc
+++ b/src/modules/drivers/common/ata/BusMasterIde.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -26,6 +25,7 @@
 #include <processor/MemoryRegion.h>
 #include <processor/PhysicalMemoryManager.h>
 #include <LockGuard.h>
+#include <Log.h>
 
 BusMasterIde::BusMasterIde() :
     m_pBase(0), m_PrdTableLock(false), m_PrdTable(0), m_LastPrdTableOffset(0),

--- a/src/modules/drivers/common/cdi/CdiDisk.cc
+++ b/src/modules/drivers/common/cdi/CdiDisk.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,8 +22,9 @@
 #include <Log.h>
 #include <ServiceManager.h>
 #include <utilities/assert.h>
-
-#include <vfs/VFS.h>
+#include <ServiceManager.h>
+#include <ServiceFeatures.h>
+#include <Service.h>
 
 // Prototypes in the extern "C" block to ensure that they are not mangled
 extern "C" {

--- a/src/modules/drivers/common/cdi/cdi.cc
+++ b/src/modules/drivers/common/cdi/cdi.cc
@@ -22,6 +22,9 @@
 #include <machine/Pci.h>
 #endif
 
+#include <utilities/StaticString.h>
+#include <Log.h>
+
 static cdi_list_t drivers = NULL;
 static cdi_list_t devices = NULL;
 

--- a/src/modules/drivers/common/dma/x86/X86IsaDma.cc
+++ b/src/modules/drivers/common/dma/x86/X86IsaDma.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,8 +18,15 @@
  */
 
 #include "X86IsaDma.h"
+#include <Log.h>
 
 X86IsaDma X86IsaDma::m_Instance;
+
+X86IsaDma::X86IsaDma() : m_Io("isa-dma")
+{
+    if(!m_Io.allocate(0, 0x100))
+        ERROR("X86IsaDma: Couldn't allocate port range");
+};
 
 bool X86IsaDma::initTransfer(uint8_t channel, uint8_t mode, size_t length, uintptr_t addr)
 {

--- a/src/modules/drivers/common/dma/x86/X86IsaDma.h
+++ b/src/modules/drivers/common/dma/x86/X86IsaDma.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -123,11 +122,7 @@ class X86IsaDma : public IsaDma
             Block = (2 << 6)
         };
 
-        X86IsaDma() : m_Io("isa-dma")
-        {
-            if(!m_Io.allocate(0, 0x100))
-                ERROR("X86IsaDma: Couldn't allocate port range");
-        };
+        X86IsaDma();
         virtual ~X86IsaDma()
         {};
 

--- a/src/modules/drivers/common/partition/PartitionService.h
+++ b/src/modules/drivers/common/partition/PartitionService.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,8 +22,8 @@
 
 #include <processor/types.h>
 
-#include <ServiceManager.h>
-//#include <ServiceFeatures.h>
+#include <Service.h>
+#include <ServiceFeatures.h>
 
 class PartitionService : public Service
 {

--- a/src/modules/drivers/common/partition/msdos.cc
+++ b/src/modules/drivers/common/partition/msdos.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,6 +22,7 @@
 #include <Log.h>
 #include "Partition.h"
 #include <Spinlock.h>
+#include <LockGuard.h>
 
 // Partition number for a DOS extended partition (another partition table)
 const uint8_t g_ExtendedPartitionNumber = 5;

--- a/src/modules/drivers/common/scsi/ScsiDisk.cc
+++ b/src/modules/drivers/common/scsi/ScsiDisk.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,7 +20,9 @@
 #include <processor/types.h>
 #include <utilities/assert.h>
 #include <utilities/Cache.h>
+#include <Service.h>
 #include <ServiceManager.h>
+#include <ServiceFeatures.h>
 #include "ScsiDisk.h"
 #include "ScsiCommands.h"
 #include "ScsiController.h"

--- a/src/modules/drivers/common/usb-hcd/Ehci.cc
+++ b/src/modules/drivers/common/usb-hcd/Ehci.cc
@@ -23,9 +23,11 @@
 #endif
 #include <processor/Processor.h>
 #include <processor/InterruptManager.h>
+#include <processor/IoBase.h>
 #include <usb/Usb.h>
 #include <utilities/assert.h>
 #include <Log.h>
+#include <LockGuard.h>
 #include "Ehci.h"
 
 #define delay(n) do{Semaphore semWAIT(0);semWAIT.acquire(1, 0, n * 1000);}while(0)

--- a/src/modules/drivers/common/usb-hcd/Ohci.cc
+++ b/src/modules/drivers/common/usb-hcd/Ohci.cc
@@ -19,11 +19,13 @@
 
 #include <machine/Machine.h>
 #include <processor/Processor.h>
+#include <processor/IoBase.h>
 #include <usb/Usb.h>
 #include <Log.h>
 #ifdef X86_COMMON
 #include <machine/Pci.h>
 #endif
+#include <LockGuard.h>
 #include "Ohci.h"
 
 #define delay(n) do{Semaphore semWAIT(0);semWAIT.acquire(1, 0, n*1000);}while(0)

--- a/src/modules/drivers/common/usb-hcd/Uhci.cc
+++ b/src/modules/drivers/common/usb-hcd/Uhci.cc
@@ -22,8 +22,10 @@
 #include <machine/Machine.h>
 #include <machine/Pci.h>
 #include <processor/Processor.h>
+#include <processor/IoBase.h>
 #include <usb/Usb.h>
 #include <Log.h>
+#include <LockGuard.h>
 #include "Uhci.h"
 
 #define delay(n) do{Semaphore semWAIT(0);semWAIT.acquire(1, 0, n*1000);}while(0)

--- a/src/modules/drivers/x86/ib700_wdt/main.cc
+++ b/src/modules/drivers/x86/ib700_wdt/main.cc
@@ -24,6 +24,8 @@
 #include <machine/Machine.h>
 #include <machine/TimerHandler.h>
 #include <machine/Timer.h>
+#include <processor/IoBase.h>
+#include <Log.h>
 
 enum Ib700TimeEntries
 {

--- a/src/modules/drivers/x86/ne2k/Ne2k.cc
+++ b/src/modules/drivers/x86/ne2k/Ne2k.cc
@@ -26,6 +26,7 @@
 #include <processor/Processor.h>
 #include <machine/IrqManager.h>
 #include <process/Scheduler.h>
+#include <LockGuard.h>
 
 // #define NE2K_NO_THREADS
 

--- a/src/modules/drivers/x86/vbe/VbeDisplay.h
+++ b/src/modules/drivers/x86/vbe/VbeDisplay.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -24,6 +23,7 @@
 #include <machine/Device.h>
 #include <machine/Display.h>
 #include <utilities/List.h>
+#include <utilities/Tree.h>
 #include <utilities/MemoryAllocator.h>
 #include <processor/MemoryMappedIo.h>
 #include <processor/PhysicalMemoryManager.h>

--- a/src/modules/drivers/x86/vbe/vbe.cc
+++ b/src/modules/drivers/x86/vbe/vbe.cc
@@ -30,6 +30,8 @@
 
 #include <graphics/Graphics.h>
 #include <graphics/GraphicsService.h>
+#include <ServiceManager.h>
+#include <Service.h>
 
 #include <machine/x86_common/Bios.h>
 

--- a/src/modules/drivers/x86/vmware-gfx/main.cc
+++ b/src/modules/drivers/x86/vmware-gfx/main.cc
@@ -34,6 +34,8 @@
 #include <machine/Framebuffer.h>
 #include <graphics/Graphics.h>
 #include <graphics/GraphicsService.h>
+#include <ServiceManager.h>
+#include <Service.h>
 
 #include "vm_device_version.h"
 #include "svga_reg.h"

--- a/src/modules/system/TUI/Console.cc
+++ b/src/modules/system/TUI/Console.cc
@@ -20,6 +20,7 @@
 #include "Console.h"
 #include <panic.h>
 #include <utilities/assert.h>
+#include <LockGuard.h>
 
 UserConsole::UserConsole() :
     RequestQueue(), m_pReq(0), m_pPendingReq(0)

--- a/src/modules/system/console/Console.cc
+++ b/src/modules/system/console/Console.cc
@@ -22,6 +22,7 @@
 #include <Module.h>
 
 #include <process/Scheduler.h>
+#include <LockGuard.h>
 
 // c_cc array indices, and their default character.
 #define VEOF        4 // 0x04

--- a/src/modules/system/dhcpclient/DhcpService.h
+++ b/src/modules/system/dhcpclient/DhcpService.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,7 +22,8 @@
 
 #include <processor/types.h>
 
-#include <ServiceManager.h>
+#include <Service.h>
+#include <ServiceFeatures.h>
 
 class DhcpService : public Service
 {

--- a/src/modules/system/ext2/Ext2Filesystem.cc
+++ b/src/modules/system/ext2/Ext2Filesystem.cc
@@ -25,10 +25,13 @@
 #include <Module.h>
 #include <machine/Machine.h>
 #include <machine/Timer.h>
+#include <machine/Disk.h>
 #include <process/Process.h>
 #include <processor/Processor.h>
 #include <syscallError.h>
 #include <users/UserManager.h>
+#include <users/User.h>
+#include <users/Group.h>
 #include <utilities/List.h>
 #include <utilities/StaticString.h>
 #include <utilities/assert.h>

--- a/src/modules/system/ext2/Ext2Node.cc
+++ b/src/modules/system/ext2/Ext2Node.cc
@@ -21,6 +21,7 @@
 #include "Ext2Filesystem.h"
 #include <utilities/assert.h>
 #include <syscallError.h>
+#include <Log.h>
 
 Ext2Node::Ext2Node(uintptr_t inode_num, Inode *pInode, Ext2Filesystem *pFs) :
     m_pInode(pInode), m_InodeNumber(inode_num), m_pExt2Fs(pFs), m_pBlocks(0),

--- a/src/modules/system/fat/FatFilesystem.cc
+++ b/src/modules/system/fat/FatFilesystem.cc
@@ -20,11 +20,14 @@
 #include <Log.h>
 #include <Module.h>
 #include <processor/Processor.h>
+#include <process/Scheduler.h>
 #include <syscallError.h>
+#include <machine/Disk.h>
 #include <utilities/List.h>
 #include <utilities/StaticString.h>
 #include <utilities/assert.h>
 #include <utilities/utility.h>
+#include <time/Time.h>
 #include <vfs/VFS.h>
 
 #include "fat.h"

--- a/src/modules/system/init/main.cc
+++ b/src/modules/system/init/main.cc
@@ -19,7 +19,6 @@
 
 #include <Log.h>
 #include <vfs/VFS.h>
-#include <vfs/Directory.h>
 #include <subsys/posix/PosixSubsystem.h> // In src
 #include <machine/Device.h>
 #include <machine/Disk.h>
@@ -31,32 +30,23 @@
 #include <process/Scheduler.h>
 #include <processor/PhysicalMemoryManager.h>
 #include <processor/VirtualAddressSpace.h>
-#include <machine/Machine.h>
 #include <linker/DynamicLinker.h>
-#include <panic.h>
-#include <utilities/assert.h>
 
 #include <core/BootIO.h> // In src/system/kernel
 
 #include <network-stack/NetworkStack.h>
 #include <network-stack/RoutingTable.h>
-#include <network-stack/UdpLogger.h>
 
 #include <ramfs/RamFs.h>
 
 #include <users/UserManager.h>
-
-#include <utilities/TimeoutGuard.h>
-
-#include <config/ConfigurationManager.h>
-#include <config/MemoryBackend.h>
+#include <users/User.h>
 
 #include <machine/DeviceHashTree.h>
 #include <lodisk/LoDisk.h>
 
-#include <machine/InputManager.h>
-
 #include <ServiceManager.h>
+#include <Service.h>
 
 extern void pedigree_init_sigret();
 extern void pedigree_init_pthreads();

--- a/src/modules/system/iso9660/Iso9660Directory.cc
+++ b/src/modules/system/iso9660/Iso9660Directory.cc
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2008-2014, Pedigree Developers
+ *
+ * Please see the CONTRIB file in the root of the source tree for a full
+ * list of contributors.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "Iso9660Directory.h"
+#include "Iso9660File.h"
+#include <machine/Disk.h>
+#include <time/Time.h>
+#include <Log.h>
+
+Iso9660Directory::Iso9660Directory(String name, size_t inode,
+    class Iso9660Filesystem *pFs, File *pParent, Iso9660DirRecord &dirRec,
+    Time accessedTime, Time modifiedTime, Time creationTime) :
+        Directory(name, accessedTime, modifiedTime, creationTime, inode, pFs, 0, pParent),
+        m_Dir(dirRec), m_pFs(pFs)
+{}
+
+void Iso9660Directory::cacheDirectoryContents()
+{
+  if(!m_pFs)
+  {
+      ERROR("ISO9660: m_pFs is null!");
+      return;
+  }
+    
+  Disk *myDisk = m_pFs->getDisk();
+
+  // Grab our parent (will always be a directory)
+  Iso9660Directory *pParentDir = reinterpret_cast<Iso9660Directory*>(m_pParent);
+  if(pParentDir == 0)
+  {
+    // Root directory, . and .. should redirect to this directory
+    Iso9660Directory *dot = new Iso9660Directory(String("."), m_Inode, m_pFs, m_pParent, m_Dir, m_AccessedTime, m_ModifiedTime, m_CreationTime);
+    Iso9660Directory *dotdot = new Iso9660Directory(String(".."), m_Inode, m_pFs, m_pParent, m_Dir, m_AccessedTime, m_ModifiedTime, m_CreationTime);
+    m_Cache.insert(String("."), dot);
+    m_Cache.insert(String(".."), dotdot);
+  }
+  else
+  {
+    // Non-root, . and .. should point to the correct locations
+    Iso9660Directory *dot = new Iso9660Directory(String("."), m_Inode, m_pFs, m_pParent, m_Dir, m_AccessedTime, m_ModifiedTime, m_CreationTime);
+    m_Cache.insert(String("."), dot);
+
+    Iso9660Directory *dotdot = new Iso9660Directory(String(".."),
+                                                  pParentDir->getInode(),
+                                                  pParentDir->m_pFs,
+                                                  pParentDir->getParent(),
+                                                  pParentDir->getDirRecord(),
+                                                  pParentDir->getAccessedTime(),
+                                                  pParentDir->getModifiedTime(),
+                                                  pParentDir->getCreationTime()
+                                                  );
+    m_Cache.insert(String(".."), dotdot);
+  }
+
+  // How big is the directory?
+  size_t dirSize = LITTLE_TO_HOST32(m_Dir.DataLen_LE);
+  size_t dirLoc = LITTLE_TO_HOST32(m_Dir.ExtentLocation_LE);
+
+  // Read the directory, block by block
+  size_t numBlocks = (dirSize > 2048) ? dirSize / 2048 : 1;
+  size_t i;
+  for(i = 0; i < numBlocks; i++)
+  {
+    // Read the block
+    uintptr_t block = myDisk->read((dirLoc + i) * 2048);
+
+    // Complete, so start reading entries
+    size_t offset = 0;
+    bool bLastHit = false;
+    while(offset < 2048)
+    {
+      Iso9660DirRecord *record = reinterpret_cast<Iso9660DirRecord*>(block + offset);
+      offset += record->RecLen;
+
+      if(record->RecLen == 0)
+      {
+        bLastHit = true;
+        break;
+      }
+      else if(record->FileFlags & (1 << 0))
+        continue;
+      else if(record->FileFlags & (1 << 1) && record->FileIdentLen == 1)
+      {
+        if(record->FileIdent[0] == 0 || record->FileIdent[0] == 1)
+          continue;
+      }
+
+      String fileName = m_pFs->parseName(*record);
+
+      // Grab the UNIX timestamp
+      Time unixTime = m_pFs->timeToUnix(record->Time);
+      if(record->FileFlags & (1 << 1))
+      {
+        Iso9660Directory *dir = new Iso9660Directory(fileName, 0, m_pFs, this, *record, unixTime, unixTime, unixTime);
+        m_Cache.insert(fileName, dir);
+      }
+      else
+      {
+        Iso9660File *file = new Iso9660File(fileName, unixTime, unixTime, unixTime, 0, m_pFs, LITTLE_TO_HOST32(record->DataLen_LE), *record, this);
+        m_Cache.insert(fileName, file);
+      }
+    }
+
+    // Last in the block, but are there still blocks to read?
+    if(bLastHit && ((i + 1) == numBlocks))
+      break;
+
+    offset = 0;
+  }
+
+  m_bCachePopulated = true;
+}

--- a/src/modules/system/iso9660/Iso9660Directory.h
+++ b/src/modules/system/iso9660/Iso9660Directory.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -41,109 +40,11 @@ private:
   Iso9660Directory& operator =(const Iso9660Directory&);
 public:
   Iso9660Directory(String name, size_t inode,
-              class Iso9660Filesystem *pFs, File *pParent, Iso9660DirRecord &dirRec,
-              Time accessedTime = 0, Time modifiedTime = 0, Time creationTime = 0) :
-    Directory(name, accessedTime, modifiedTime, creationTime, inode, pFs, 0, pParent),
-    m_Dir(dirRec), m_pFs(pFs)
-  {}
+      class Iso9660Filesystem *pFs, File *pParent, Iso9660DirRecord &dirRec,
+      Time accessedTime = 0, Time modifiedTime = 0, Time creationTime = 0);
   virtual ~Iso9660Directory() {};
 
-  virtual void cacheDirectoryContents()
-  {
-    if(!m_pFs)
-    {
-        ERROR("ISO9660: m_pFs is null!");
-        return;
-    }
-      
-    Disk *myDisk = m_pFs->getDisk();
-
-    // Grab our parent (will always be a directory)
-    Iso9660Directory *pParentDir = reinterpret_cast<Iso9660Directory*>(m_pParent);
-    if(pParentDir == 0)
-    {
-      // Root directory, . and .. should redirect to this directory
-      Iso9660Directory *dot = new Iso9660Directory(String("."), m_Inode, m_pFs, m_pParent, m_Dir, m_AccessedTime, m_ModifiedTime, m_CreationTime);
-      Iso9660Directory *dotdot = new Iso9660Directory(String(".."), m_Inode, m_pFs, m_pParent, m_Dir, m_AccessedTime, m_ModifiedTime, m_CreationTime);
-      m_Cache.insert(String("."), dot);
-      m_Cache.insert(String(".."), dotdot);
-    }
-    else
-    {
-      // Non-root, . and .. should point to the correct locations
-      Iso9660Directory *dot = new Iso9660Directory(String("."), m_Inode, m_pFs, m_pParent, m_Dir, m_AccessedTime, m_ModifiedTime, m_CreationTime);
-      m_Cache.insert(String("."), dot);
-
-      Iso9660Directory *dotdot = new Iso9660Directory(String(".."),
-                                                    pParentDir->getInode(),
-                                                    pParentDir->m_pFs,
-                                                    pParentDir->getParent(),
-                                                    pParentDir->getDirRecord(),
-                                                    pParentDir->getAccessedTime(),
-                                                    pParentDir->getModifiedTime(),
-                                                    pParentDir->getCreationTime()
-                                                    );
-      m_Cache.insert(String(".."), dotdot);
-    }
-
-    // How big is the directory?
-    size_t dirSize = LITTLE_TO_HOST32(m_Dir.DataLen_LE);
-    size_t dirLoc = LITTLE_TO_HOST32(m_Dir.ExtentLocation_LE);
-
-    // Read the directory, block by block
-    size_t numBlocks = (dirSize > 2048) ? dirSize / 2048 : 1;
-    size_t i;
-    for(i = 0; i < numBlocks; i++)
-    {
-      // Read the block
-      uintptr_t block = myDisk->read((dirLoc + i) * 2048);
-
-      // Complete, so start reading entries
-      size_t offset = 0;
-      bool bLastHit = false;
-      while(offset < 2048)
-      {
-        Iso9660DirRecord *record = reinterpret_cast<Iso9660DirRecord*>(block + offset);
-        offset += record->RecLen;
-
-        if(record->RecLen == 0)
-        {
-          bLastHit = true;
-          break;
-        }
-        else if(record->FileFlags & (1 << 0))
-          continue;
-        else if(record->FileFlags & (1 << 1) && record->FileIdentLen == 1)
-        {
-          if(record->FileIdent[0] == 0 || record->FileIdent[0] == 1)
-            continue;
-        }
-
-        String fileName = m_pFs->parseName(*record);
-
-        // Grab the UNIX timestamp
-        Time unixTime = m_pFs->timeToUnix(record->Time);
-        if(record->FileFlags & (1 << 1))
-        {
-          Iso9660Directory *dir = new Iso9660Directory(fileName, 0, m_pFs, this, *record, unixTime, unixTime, unixTime);
-          m_Cache.insert(fileName, dir);
-        }
-        else
-        {
-          Iso9660File *file = new Iso9660File(fileName, unixTime, unixTime, unixTime, 0, m_pFs, LITTLE_TO_HOST32(record->DataLen_LE), *record, this);
-          m_Cache.insert(fileName, file);
-        }
-      }
-
-      // Last in the block, but are there still blocks to read?
-      if(bLastHit && ((i + 1) == numBlocks))
-        break;
-
-      offset = 0;
-    }
-
-    m_bCachePopulated = true;
-  }
+  virtual void cacheDirectoryContents();
 
   virtual bool addEntry(String filename, File *pFile, size_t type)
   {

--- a/src/modules/system/iso9660/Iso9660Filesystem.cc
+++ b/src/modules/system/iso9660/Iso9660Filesystem.cc
@@ -26,6 +26,7 @@
 #include <processor/Processor.h>
 #include <utilities/StaticString.h>
 #include <syscallError.h>
+#include <machine/Disk.h>
 
 #include <utilities/assert.h>
 #include <utilities/PointerGuard.h>

--- a/src/modules/system/iso9660/Iso9660Filesystem.h
+++ b/src/modules/system/iso9660/Iso9660Filesystem.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,10 +21,12 @@
 #define ISO9660FILESYSTEM_H
 
 #include <vfs/Filesystem.h>
+#include <vfs/File.h>
 #include <utilities/List.h>
 #include <utilities/Vector.h>
 #include <utilities/Tree.h>
 #include <process/Mutex.h>
+#include <time/Time.h>
 #include <LockGuard.h>
 
 #include "iso9660.h"

--- a/src/modules/system/lodisk/LoDisk.cc
+++ b/src/modules/system/lodisk/LoDisk.cc
@@ -22,6 +22,9 @@
 #include <utilities/assert.h>
 
 #include <ServiceManager.h>
+#include <ServiceFeatures.h>
+#include <Service.h>
+#include <LockGuard.h>
 
 FileDisk::FileDisk(String file, AccessType mode) :
     m_pFile(0), m_Mode(mode), m_Cache(), m_MemRegion("FileDisk"),

--- a/src/modules/system/network-stack/Ipv6.h
+++ b/src/modules/system/network-stack/Ipv6.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -29,7 +28,8 @@
 #include <LockGuard.h>
 #include <Spinlock.h>
 
-#include <ServiceManager.h>
+#include <Service.h>
+#include <ServiceFeatures.h>
 
 #include "NetworkStack.h"
 #include "Ethernet.h"

--- a/src/modules/system/network-stack/NetManager.h
+++ b/src/modules/system/network-stack/NetManager.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,6 +22,7 @@
 
 #include <vfs/VFS.h>
 #include <vfs/Filesystem.h>
+#include <vfs/File.h>
 #include <utilities/RequestQueue.h>
 #include <utilities/Vector.h>
 #include <process/Scheduler.h>

--- a/src/modules/system/network-stack/NetworkStack.cc
+++ b/src/modules/system/network-stack/NetworkStack.cc
@@ -24,6 +24,8 @@
 #include <Log.h>
 #include <processor/Processor.h>
 
+#include <ServiceManager.h>
+
 #include "Dns.h"
 
 NetworkStack NetworkStack::stack;

--- a/src/modules/system/network-stack/Tcp.cc
+++ b/src/modules/system/network-stack/Tcp.cc
@@ -18,10 +18,8 @@
  */
 
 #include "Tcp.h"
-#include <Module.h>
 #include <Log.h>
 
-#include "Ethernet.h"
 #include "Ipv4.h"
 #include "Ipv6.h"
 
@@ -31,7 +29,6 @@
 
 #include "Filter.h"
 
-#include "Arp.h"
 #include "IpCommon.h"
 
 Tcp Tcp::tcpInstance;

--- a/src/modules/system/network-stack/TcpEndpoint.cc
+++ b/src/modules/system/network-stack/TcpEndpoint.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -18,6 +17,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include "TcpEndpoint.h"
 #include "NetManager.h"
 #include "TcpManager.h"
 #include <Log.h>

--- a/src/modules/system/network-stack/TcpEndpoint.h
+++ b/src/modules/system/network-stack/TcpEndpoint.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -24,15 +23,15 @@
 #include <processor/types.h>
 #include <utilities/List.h>
 #include <process/Semaphore.h>
-#include <machine/Network.h>
 
 #include <Log.h>
 
 #include "ConnectionBasedEndpoint.h"
 #include "Endpoint.h"
 #include "TcpMisc.h"
-class TcpManager;
-class StateBlock;
+#include "Tcp.h"
+
+class Network;
 
 /**
  * The Pedigree network stack - TCP Endpoint

--- a/src/modules/system/network-stack/TcpManager.cc
+++ b/src/modules/system/network-stack/TcpManager.cc
@@ -18,6 +18,7 @@
  */
 
 #include "TcpManager.h"
+#include "TcpEndpoint.h"
 #include "RoutingTable.h"
 #include <Log.h>
 #include <processor/Processor.h>

--- a/src/modules/system/network-stack/TcpManager.h
+++ b/src/modules/system/network-stack/TcpManager.h
@@ -22,24 +22,23 @@
 
 #include <utilities/String.h>
 #include <utilities/Tree.h>
-#include <utilities/List.h>
 #include <processor/types.h>
-#include <process/Semaphore.h>
-#include <machine/Network.h>
 #include <process/Mutex.h>
 #include <machine/TimerHandler.h>
+#include <network/IpAddress.h>
 #include <LockGuard.h>
 
 #include <Log.h>
 
 #include "Manager.h"
 
-#include "NetworkStack.h"
 #include "Tcp.h"
 #include "TcpMisc.h"
 #include "Endpoint.h"
-#include "TcpEndpoint.h"
 #include "TcpStateBlock.h"
+
+class Network;
+class TcpEndpoint;
 
 #define BASE_EPHEMERAL_PORT 32768
 

--- a/src/modules/system/network-stack/TcpManagerReceive.cc
+++ b/src/modules/system/network-stack/TcpManagerReceive.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,6 +18,7 @@
  */
 
 #include "TcpManager.h"
+#include "TcpEndpoint.h"
 #include <Log.h>
 
 #include <process/Mutex.h>

--- a/src/modules/system/network-stack/TcpMisc.cc
+++ b/src/modules/system/network-stack/TcpMisc.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,7 +21,6 @@
 #include "TcpMisc.h"
 #include "TcpStateBlock.h"
 #include <LockGuard.h>
-#include <Log.h>
 
 int stateBlockFree(void* p)
 {

--- a/src/modules/system/network-stack/TcpMisc.h
+++ b/src/modules/system/network-stack/TcpMisc.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -26,8 +25,6 @@
 #include <process/Mutex.h>
 #include <LockGuard.h>
 #include "Endpoint.h"
-
-#include <Log.h>
 
 /** A TCP "Buffer" (also known as a stream) */
 class TcpBuffer

--- a/src/modules/system/network-stack/TcpStateBlock.cc
+++ b/src/modules/system/network-stack/TcpStateBlock.cc
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2008-2014, Pedigree Developers
+ *
+ * Please see the CONTRIB file in the root of the source tree for a full
+ * list of contributors.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "TcpStateBlock.h"
+#include "TcpEndpoint.h"
+#include "Tcp.h"
+#include <Log.h>
+
+StateBlock::StateBlock() :
+  currentState(Tcp::CLOSED), localPort(0), remoteHost(),
+  iss(0), snd_nxt(0), snd_una(0), snd_wnd(0), snd_up(0), snd_wl1(0), snd_wl2(0),
+  rcv_nxt(0), rcv_wnd(0), rcv_up(0), irs(0),
+  seg_seq(0), seg_ack(0), seg_len(0), seg_wnd(0), seg_up(0), seg_prc(0),
+  fin_ack(false), fin_seq(0), tcp_mss(536), // (standard default for MSS)
+  numEndpointPackets(0), /// \todo Remove, obsolete
+  waitState(0), endpoint(0), connId(0),
+  retransmitQueue(), nRemovedFromRetransmit(0),
+  waitingForTimeout(false), didTimeout(false), timeoutWait(0), useWaitSem(true),
+  m_Nanoseconds(0), m_Seconds(0), m_Timeout(10)
+{
+  Timer* t = Machine::instance().getTimer();
+  if(t)
+    t->registerHandler(this);
+}
+
+StateBlock::~StateBlock()
+{
+  Timer* t = Machine::instance().getTimer();
+  if(t)
+    t->unregisterHandler(this);
+}
+
+StateBlock::StateBlock(const StateBlock& s) :
+  currentState(Tcp::CLOSED), localPort(0), remoteHost(),
+  iss(0), snd_nxt(0), snd_una(0), snd_wnd(0), snd_up(0), snd_wl1(0), snd_wl2(0),
+  rcv_nxt(0), rcv_wnd(0), rcv_up(0), irs(0),
+  seg_seq(0), seg_ack(0), seg_len(0), seg_wnd(0), seg_up(0), seg_prc(0),
+  fin_ack(false), fin_seq(0),
+  numEndpointPackets(0), /// \todo Remove, obsolete
+  waitState(0), endpoint(0), connId(0),
+  retransmitQueue(), nRemovedFromRetransmit(0),
+  waitingForTimeout(false), didTimeout(false), timeoutWait(0), useWaitSem(true),
+  m_Nanoseconds(0), m_Seconds(0), m_Timeout(10)
+{
+  // same as TcpEndpoint - the copy constructor should not be called
+  ERROR("Tcp: StateBlock copy constructor called");
+}
+
+StateBlock& StateBlock::operator = (const StateBlock& s)
+{
+  // this isn't actually correct EITHER
+  ERROR("Tcp: StateBlock copy constructor has been called.");
+  return *this;
+}
+
+void StateBlock::ackSegment()
+{
+  // we assume the seg_* variables have been set by the caller (always done in TcpManager::receive)
+  uint32_t segAck = seg_ack;
+  while(retransmitQueue.count())
+  {
+    // grab the first segment from the queue
+    Segment* seg = reinterpret_cast<Segment*>(retransmitQueue.popFront());
+    if((seg->seg_seq + seg->seg_len) <= segAck)
+    {
+      // this segment is acked, leave it off the queue and free the memory used
+      if(seg->payload)
+        delete [] (reinterpret_cast<uint8_t*>(seg->payload));
+
+      delete seg;
+      continue;
+    }
+    else
+    {
+      // check if the ack is within this segment
+      if(segAck >= seg->seg_seq)
+      {
+        // it is, so we need to split the segment payload
+        Segment* splitSeg = new Segment;
+        *splitSeg = *seg;
+
+        // how many bytes are acked?
+        /// \bug This calculation *may* have an off-by-one error
+        size_t nBytesAcked = segAck - seg->seg_seq;
+
+        // update the sequence number
+        splitSeg->seg_seq = seg->seg_seq + nBytesAcked;
+        splitSeg->seg_len -= nBytesAcked;
+
+        // and most importantly, recopy the payload
+        if(seg->nBytes && seg->payload)
+        {
+          uint8_t* newPayload = new uint8_t[splitSeg->seg_len];
+          memcpy(newPayload, reinterpret_cast<void*>(seg->payload), seg->nBytes);
+
+          splitSeg->payload = reinterpret_cast<uintptr_t>(newPayload);
+        }
+
+        // push on the front, and don't continue (we know there's no potential for further ACKs)
+        retransmitQueue.pushFront(reinterpret_cast<void*>(splitSeg));
+        if(seg->payload)
+          delete [] (reinterpret_cast<uint8_t*>(seg->payload));
+        delete seg;
+        return;
+      }
+    }
+  }
+}
+
+/// Sends a segment over the network
+bool StateBlock::sendSegment(Segment* seg)
+{
+  if(seg)
+  {
+    if((seg->flags & Tcp::ACK) == 0)
+    {
+      // If no ACK flag, don't transmit an ACK number.
+      seg->seg_ack = 0;
+    }
+    return Tcp::send(remoteHost.ip, localPort, remoteHost.remotePort, seg->seg_seq, seg->seg_ack, seg->flags, seg->seg_wnd, seg->nBytes, seg->payload);
+  }
+  return false;
+}
+
+/// Sends a segment over the network
+bool StateBlock::sendSegment(uint8_t flags, size_t nBytes, uintptr_t payload, bool addToRetransmitQueue)
+{
+  // split the passed buffer up into segments based on the MSS and send each
+  size_t offset;
+  for(offset = 0; offset < (nBytes == 0 ? 1 : nBytes); offset += tcp_mss)
+  {
+    Segment* seg = new Segment;
+
+    size_t segmentSize = tcp_mss;
+    if((offset + segmentSize) >= nBytes)
+    {
+      segmentSize = nBytes - offset;
+      if(nBytes)
+      {
+         flags |= Tcp::PSH;
+      }
+    }
+
+    seg_seq = snd_nxt;
+    snd_nxt += segmentSize;
+    snd_wnd = endpoint->m_ShadowDataStream.getRemainingSize();
+
+    seg->seg_seq = seg_seq;
+    seg->seg_ack = rcv_nxt;
+    seg->seg_len = segmentSize;
+    seg->seg_wnd = snd_wnd;
+    seg->seg_up = 0;
+    seg->flags = flags;
+
+    if(nBytes && payload)
+    {
+      uint8_t* newPayload = new uint8_t[segmentSize];
+      memcpy(newPayload, reinterpret_cast<void*>(payload + offset), segmentSize);
+
+      seg->payload = reinterpret_cast<uintptr_t>(newPayload);
+    }
+    else
+      seg->payload = 0;
+    seg->nBytes = seg->seg_len;
+
+    sendSegment(seg);
+
+    if(addToRetransmitQueue)
+      retransmitQueue.pushBack(reinterpret_cast<void*>(seg));
+    else
+      delete seg;
+  }
+
+  return true;
+}
+
+// timer for all retransmissions (and state changes such as TIME_WAIT)
+void StateBlock::timer(uint64_t delta, InterruptState& state)
+{
+  if(!waitingForTimeout)
+    return;
+
+  if(UNLIKELY(m_Seconds < m_Timeout))
+  {
+    m_Nanoseconds += delta;
+    if(UNLIKELY(m_Nanoseconds >= 1000000000ULL))
+    {
+      ++m_Seconds;
+      m_Nanoseconds -= 1000000000ULL;
+    }
+
+    if(UNLIKELY(m_Seconds >= m_Timeout))
+    {
+      // timeout is hit!
+      waitingForTimeout = false;
+      didTimeout = true;
+      if(useWaitSem)
+        timeoutWait.release();
+
+      // check to see if there's data on the retransmission queue to send
+      if(retransmitQueue.count())
+      {
+        NOTICE("Remote TCP did not ack all the data!");
+
+        // still more data unacked - grab the first segment and transmit it
+        // note that we don't pop it off the queue permanently, as we are still
+        // waiting for an ack for the segment
+        Segment* seg = reinterpret_cast<Segment*>(retransmitQueue.popFront());
+        sendSegment(seg);
+        retransmitQueue.pushFront(reinterpret_cast<void*>(seg));
+
+        // reset the timeout
+        resetTimer();
+      }
+      else if(currentState == Tcp::TIME_WAIT)
+      {
+        // timer has fired, we need to close the connection
+        NOTICE("TIME_WAIT timeout complete");
+        currentState = Tcp::CLOSED;
+
+        // create the cleanup thread
+        Thread *pThread = new Thread(Processor::information().getCurrentThread()->getParent(),
+                                     reinterpret_cast<Thread::ThreadStartFunc> (&stateBlockFree),
+                                     reinterpret_cast<void*> (this));
+        pThread->detach();
+      }
+    }
+  }
+}
+
+// resets the timer (to restart a timeout)
+void StateBlock::resetTimer(uint32_t timeout)
+{
+  m_Seconds = m_Nanoseconds = 0;
+  m_Timeout = timeout;
+  didTimeout = false;
+}

--- a/src/modules/system/network-stack/TcpStateBlock.h
+++ b/src/modules/system/network-stack/TcpStateBlock.h
@@ -21,7 +21,9 @@
 #define TCPSTATEBLOCK_H
 
 #include <processor/types.h>
+#include <machine/Machine.h>
 #include <machine/Network.h>
+#include <machine/Timer.h>
 #include <process/Semaphore.h>
 #include <processor/Processor.h>
 
@@ -29,6 +31,8 @@
 #include "Endpoint.h"
 #include "TcpMisc.h"
 #include "Tcp.h"
+
+class TcpEndpoint;
 
 /// \todo Eventify.
 
@@ -58,28 +62,8 @@ class StateBlock : public TimerHandler
     };
 
   public:
-    StateBlock() :
-      currentState(Tcp::CLOSED), localPort(0), remoteHost(),
-      iss(0), snd_nxt(0), snd_una(0), snd_wnd(0), snd_up(0), snd_wl1(0), snd_wl2(0),
-      rcv_nxt(0), rcv_wnd(0), rcv_up(0), irs(0),
-      seg_seq(0), seg_ack(0), seg_len(0), seg_wnd(0), seg_up(0), seg_prc(0),
-      fin_ack(false), fin_seq(0), tcp_mss(536), // (standard default for MSS)
-      numEndpointPackets(0), /// \todo Remove, obsolete
-      waitState(0), endpoint(0), connId(0),
-      retransmitQueue(), nRemovedFromRetransmit(0),
-      waitingForTimeout(false), didTimeout(false), timeoutWait(0), useWaitSem(true),
-      m_Nanoseconds(0), m_Seconds(0), m_Timeout(10)
-    {
-      Timer* t = Machine::instance().getTimer();
-      if(t)
-        t->registerHandler(this);
-    };
-    ~StateBlock()
-    {
-      Timer* t = Machine::instance().getTimer();
-      if(t)
-        t->unregisterHandler(this);
-    };
+    StateBlock();
+    ~StateBlock();
 
     Tcp::TcpState currentState;
 
@@ -142,188 +126,19 @@ class StateBlock : public TimerHandler
     ///       it will split it into two, remove the first, and leave a partial segment on the queue.
     ///       This behaviour does not affect anything internally as long as this function is always
     ///       used to acknowledge segments.
-    void ackSegment()
-    {
-      // we assume the seg_* variables have been set by the caller (always done in TcpManager::receive)
-      uint32_t segAck = seg_ack;
-      while(retransmitQueue.count())
-      {
-        // grab the first segment from the queue
-        Segment* seg = reinterpret_cast<Segment*>(retransmitQueue.popFront());
-        if((seg->seg_seq + seg->seg_len) <= segAck)
-        {
-          // this segment is acked, leave it off the queue and free the memory used
-          if(seg->payload)
-            delete [] (reinterpret_cast<uint8_t*>(seg->payload));
-
-          delete seg;
-          continue;
-        }
-        else
-        {
-          // check if the ack is within this segment
-          if(segAck >= seg->seg_seq)
-          {
-            // it is, so we need to split the segment payload
-            Segment* splitSeg = new Segment;
-            *splitSeg = *seg;
-
-            // how many bytes are acked?
-            /// \bug This calculation *may* have an off-by-one error
-            size_t nBytesAcked = segAck - seg->seg_seq;
-
-            // update the sequence number
-            splitSeg->seg_seq = seg->seg_seq + nBytesAcked;
-            splitSeg->seg_len -= nBytesAcked;
-
-            // and most importantly, recopy the payload
-            if(seg->nBytes && seg->payload)
-            {
-              uint8_t* newPayload = new uint8_t[splitSeg->seg_len];
-              memcpy(newPayload, reinterpret_cast<void*>(seg->payload), seg->nBytes);
-
-              splitSeg->payload = reinterpret_cast<uintptr_t>(newPayload);
-            }
-
-            // push on the front, and don't continue (we know there's no potential for further ACKs)
-            retransmitQueue.pushFront(reinterpret_cast<void*>(splitSeg));
-            if(seg->payload)
-              delete [] (reinterpret_cast<uint8_t*>(seg->payload));
-            delete seg;
-            return;
-          }
-        }
-      }
-    }
+    void ackSegment();
 
     /// Sends a segment over the network
-    bool sendSegment(Segment* seg)
-    {
-      if(seg)
-      {
-        if((seg->flags & Tcp::ACK) == 0)
-        {
-          // If no ACK flag, don't transmit an ACK number.
-          seg->seg_ack = 0;
-        }
-        return Tcp::send(remoteHost.ip, localPort, remoteHost.remotePort, seg->seg_seq, seg->seg_ack, seg->flags, seg->seg_wnd, seg->nBytes, seg->payload);
-      }
-      return false;
-    }
+    bool sendSegment(Segment* seg);
 
     /// Sends a segment over the network
-    bool sendSegment(uint8_t flags, size_t nBytes, uintptr_t payload, bool addToRetransmitQueue)
-    {
-      // split the passed buffer up into segments based on the MSS and send each
-      size_t offset;
-      for(offset = 0; offset < (nBytes == 0 ? 1 : nBytes); offset += tcp_mss)
-      {
-        Segment* seg = new Segment;
-
-        size_t segmentSize = tcp_mss;
-        if((offset + segmentSize) >= nBytes)
-        {
-          segmentSize = nBytes - offset;
-          if(nBytes)
-          {
-             flags |= Tcp::PSH;
-          }
-        }
-
-        seg_seq = snd_nxt;
-        snd_nxt += segmentSize;
-        snd_wnd = endpoint->m_ShadowDataStream.getRemainingSize();
-
-        seg->seg_seq = seg_seq;
-        seg->seg_ack = rcv_nxt;
-        seg->seg_len = segmentSize;
-        seg->seg_wnd = snd_wnd;
-        seg->seg_up = 0;
-        seg->flags = flags;
-
-        if(nBytes && payload)
-        {
-          uint8_t* newPayload = new uint8_t[segmentSize];
-          memcpy(newPayload, reinterpret_cast<void*>(payload + offset), segmentSize);
-
-          seg->payload = reinterpret_cast<uintptr_t>(newPayload);
-        }
-        else
-          seg->payload = 0;
-        seg->nBytes = seg->seg_len;
-
-        sendSegment(seg);
-
-        if(addToRetransmitQueue)
-          retransmitQueue.pushBack(reinterpret_cast<void*>(seg));
-        else
-          delete seg;
-      }
-
-      return true;
-    }
+    bool sendSegment(uint8_t flags, size_t nBytes, uintptr_t payload, bool addToRetransmitQueue);
 
     // timer for all retransmissions (and state changes such as TIME_WAIT)
-    virtual void timer(uint64_t delta, InterruptState& state)
-    {
-      if(!waitingForTimeout)
-        return;
-
-      if(UNLIKELY(m_Seconds < m_Timeout))
-      {
-        m_Nanoseconds += delta;
-        if(UNLIKELY(m_Nanoseconds >= 1000000000ULL))
-        {
-          ++m_Seconds;
-          m_Nanoseconds -= 1000000000ULL;
-        }
-
-        if(UNLIKELY(m_Seconds >= m_Timeout))
-        {
-          // timeout is hit!
-          waitingForTimeout = false;
-          didTimeout = true;
-          if(useWaitSem)
-            timeoutWait.release();
-
-          // check to see if there's data on the retransmission queue to send
-          if(retransmitQueue.count())
-          {
-            NOTICE("Remote TCP did not ack all the data!");
-
-            // still more data unacked - grab the first segment and transmit it
-            // note that we don't pop it off the queue permanently, as we are still
-            // waiting for an ack for the segment
-            Segment* seg = reinterpret_cast<Segment*>(retransmitQueue.popFront());
-            sendSegment(seg);
-            retransmitQueue.pushFront(reinterpret_cast<void*>(seg));
-
-            // reset the timeout
-            resetTimer();
-          }
-          else if(currentState == Tcp::TIME_WAIT)
-          {
-            // timer has fired, we need to close the connection
-            NOTICE("TIME_WAIT timeout complete");
-            currentState = Tcp::CLOSED;
-
-            // create the cleanup thread
-            Thread *pThread = new Thread(Processor::information().getCurrentThread()->getParent(),
-                                         reinterpret_cast<Thread::ThreadStartFunc> (&stateBlockFree),
-                                         reinterpret_cast<void*> (this));
-            pThread->detach();
-          }
-        }
-      }
-    }
+    virtual void timer(uint64_t delta, InterruptState& state);
 
     // resets the timer (to restart a timeout)
-    void resetTimer(uint32_t timeout = 10)
-    {
-      m_Seconds = m_Nanoseconds = 0;
-      m_Timeout = timeout;
-      didTimeout = false;
-    }
+    void resetTimer(uint32_t timeout = 10);
 
     // are we waiting on a timeout?
     bool waitingForTimeout;
@@ -345,27 +160,8 @@ class StateBlock : public TimerHandler
     uint64_t m_Seconds;
     uint32_t m_Timeout;
 
-    StateBlock(const StateBlock& s) :
-      currentState(Tcp::CLOSED), localPort(0), remoteHost(),
-      iss(0), snd_nxt(0), snd_una(0), snd_wnd(0), snd_up(0), snd_wl1(0), snd_wl2(0),
-      rcv_nxt(0), rcv_wnd(0), rcv_up(0), irs(0),
-      seg_seq(0), seg_ack(0), seg_len(0), seg_wnd(0), seg_up(0), seg_prc(0),
-      fin_ack(false), fin_seq(0),
-      numEndpointPackets(0), /// \todo Remove, obsolete
-      waitState(0), endpoint(0), connId(0),
-      retransmitQueue(), nRemovedFromRetransmit(0),
-      waitingForTimeout(false), didTimeout(false), timeoutWait(0), useWaitSem(true),
-      m_Nanoseconds(0), m_Seconds(0), m_Timeout(10)
-    {
-      // same as TcpEndpoint - the copy constructor should not be called
-      ERROR("Tcp: StateBlock copy constructor called");
-    }
-    StateBlock& operator = (const StateBlock& s)
-    {
-      // this isn't actually correct EITHER
-      ERROR("Tcp: StateBlock copy constructor has been called.");
-      return *this;
-    }
+    StateBlock(const StateBlock& s);
+    StateBlock& operator = (const StateBlock& s);
 };
 
 #endif

--- a/src/modules/system/network-stack/Udp.cc
+++ b/src/modules/system/network-stack/Udp.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,10 +18,8 @@
  */
 
 #include "Udp.h"
-#include <Module.h>
 #include <Log.h>
 
-#include "Ethernet.h"
 #include "Ipv4.h"
 #include "Ipv6.h"
 
@@ -32,7 +29,6 @@
 
 #include "Filter.h"
 
-#include "Arp.h"
 #include "IpCommon.h"
 
 Udp Udp::udpInstance;

--- a/src/modules/system/network-stack/Udp.h
+++ b/src/modules/system/network-stack/Udp.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,13 +20,11 @@
 #ifndef MACHINE_UDP_H
 #define MACHINE_UDP_H
 
-#include <utilities/String.h>
-#include <utilities/Vector.h>
 #include <processor/types.h>
-#include <process/Semaphore.h>
-#include <machine/Network.h>
+#include <network/IpAddress.h>
 
-#include "IpCommon.h"
+class Network;
+class IpBase;
 
 /**
  * The Pedigree network stack - UDP layer

--- a/src/modules/system/network-stack/UdpLogger.cc
+++ b/src/modules/system/network-stack/UdpLogger.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,9 +19,9 @@
 
 #include "UdpLogger.h"
 #include <network/IpAddress.h>
-#include "NetworkStack.h"
 #include "UdpManager.h"
-#include "RoutingTable.h"
+
+#include <network-stack/ConnectionlessEndpoint.h>
 
 UdpLogger::~UdpLogger()
 {

--- a/src/modules/system/network-stack/UdpLogger.h
+++ b/src/modules/system/network-stack/UdpLogger.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,10 +22,10 @@
 
 #include <processor/types.h>
 #include <network/IpAddress.h>
-#include "ConnectionlessEndpoint.h"
-#include "NetworkStack.h"
-#include "UdpManager.h"
+#include <network-stack/Endpoint.h>
 #include <Log.h>
+
+class ConnectionlessEndpoint;
 
 /** Defines a UDP-based callback for Log entries. */
 class UdpLogger : public Log::LogCallback

--- a/src/modules/system/network-stack/UdpManager.cc
+++ b/src/modules/system/network-stack/UdpManager.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,7 +21,7 @@
 #include "UdpManager.h"
 #include <Log.h>
 #include <syscallError.h>
-#include <processor/Processor.h>
+#include <LockGuard.h>
 
 UdpManager UdpManager::manager;
 

--- a/src/modules/system/network-stack/UdpManager.h
+++ b/src/modules/system/network-stack/UdpManager.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,12 +20,10 @@
 #ifndef MACHINE_UDPMANAGER_H
 #define MACHINE_UDPMANAGER_H
 
-#include <utilities/String.h>
 #include <utilities/Tree.h>
 #include <utilities/List.h>
 #include <process/Semaphore.h>
 #include <process/Mutex.h>
-#include <machine/Network.h>
 #include <utilities/ExtensibleBitmap.h>
 
 #include "Manager.h"
@@ -34,6 +31,8 @@
 #include "ConnectionlessEndpoint.h"
 #include "Endpoint.h"
 #include "Udp.h"
+
+class Network;
 
 /**
  * The Pedigree network stack - UDP Endpoint

--- a/src/modules/system/preload/main.cc
+++ b/src/modules/system/preload/main.cc
@@ -20,10 +20,8 @@
 #include <Log.h>
 #include <Module.h>
 #include <vfs/VFS.h>
-#include <vfs/Filesystem.h>
+#include <vfs/File.h>
 #include <process/Semaphore.h>
-#include <process/Scheduler.h>
-#include <vfs/MemoryMappedFile.h>
 
 const char *g_FilesToPreload[] = {
     "root»/applications/winman",

--- a/src/modules/system/ramfs/RamFs.cc
+++ b/src/modules/system/ramfs/RamFs.cc
@@ -17,10 +17,22 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <Log.h>
-#include <vfs/VFS.h>
 #include <Module.h>
+#include <process/Process.h>
+#include <machine/Device.h>
 #include "RamFs.h"
+
+class Disk;
+
+RamFile::RamFile(String name, uintptr_t inode, Filesystem *pParentFS, File *pParent) :
+    File(name, 0, 0, 0, inode, pParentFS, 0, pParent), m_FileBlocks(),
+    m_nOwnerPid(0)
+{
+    // Full permissions.
+    setPermissions(0777);
+
+    m_nOwnerPid = Processor::information().getCurrentThread()->getParent()->getId();
+}
 
 bool RamFile::canWrite()
 {

--- a/src/modules/system/ramfs/RamFs.h
+++ b/src/modules/system/ramfs/RamFs.h
@@ -25,25 +25,19 @@
  *\date   Sun May 17 10:00:00 2009
  *\brief  An in-RAM filesystem. */
 
-#include <vfs/VFS.h>
+#include <vfs/File.h>
 #include <vfs/Directory.h>
+#include <vfs/Filesystem.h>
 #include <processor/types.h>
-#include <machine/Disk.h>
 
 #include <utilities/Cache.h>
+
+class Disk;
 
 class RamFile : public File
 {
     public:
-        RamFile(String name, uintptr_t inode, Filesystem *pParentFS, File *pParent) :
-            File(name, 0, 0, 0, inode, pParentFS, 0, pParent), m_FileBlocks(),
-            m_nOwnerPid(0)
-        {
-            // Full permissions.
-            setPermissions(0777);
-
-            m_nOwnerPid = Processor::information().getCurrentThread()->getParent()->getId();
-        }
+        RamFile(String name, uintptr_t inode, Filesystem *pParentFS, File *pParent);
 
         virtual ~RamFile()
         {

--- a/src/modules/system/rawfs/RawFs.cc
+++ b/src/modules/system/rawfs/RawFs.cc
@@ -20,9 +20,10 @@
 #include "RawFs.h"
 #include "RawFsFile.h"
 #include "RawFsDir.h"
+#include <vfs/VFS.h>
+#include <machine/Device.h>
 
 #include <Module.h>
-#include <processor/Processor.h>
 
 RawFs *g_pRawFs;
 

--- a/src/modules/system/rawfs/RawFs.h
+++ b/src/modules/system/rawfs/RawFs.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,13 +20,10 @@
 #ifndef RAWFS_H
 #define RAWFS_H
 
-#include <process/Mutex.h>
-#include <utilities/List.h>
-#include <utilities/Tree.h>
-#include <utilities/Vector.h>
-#include <vfs/Directory.h>
 #include <vfs/Filesystem.h>
-#include <vfs/VFS.h>
+
+class Disk;
+class File;
 
 /** Provides access to Disks without mounting their contained filesystem
     (raw device access). */

--- a/src/modules/system/rawfs/RawFsDir.h
+++ b/src/modules/system/rawfs/RawFsDir.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,7 +21,9 @@
 #define RAWFS_DIRECTORY_H
 
 #include <vfs/Directory.h>
-#include <utilities/String.h>
+
+class File;
+class String;
 
 class RawFsDir : public Directory
 {

--- a/src/modules/system/rawfs/RawFsFile.cc
+++ b/src/modules/system/rawfs/RawFsFile.cc
@@ -19,6 +19,7 @@
 
 #include "RawFsFile.h"
 #include "RawFs.h"
+#include <machine/Disk.h>
 
 RawFsFile::RawFsFile(String name, RawFs *pFs, File *pParent, Disk *pDisk) :
     File(name,

--- a/src/modules/system/rawfs/RawFsFile.h
+++ b/src/modules/system/rawfs/RawFsFile.h
@@ -21,8 +21,9 @@
 #define RAWFS_FILE_H
 
 #include <vfs/File.h>
-#include <utilities/String.h>
-#include <machine/Disk.h>
+
+class Disk;
+class String;
 
 class RawFsFile : public File
 {

--- a/src/modules/system/splash/main.cc
+++ b/src/modules/system/splash/main.cc
@@ -20,15 +20,17 @@
 #include <Module.h>
 #include <Log.h>
 
-#include <utilities/assert.h>
 #include <machine/Display.h>
 #include <machine/InputManager.h>
-#include <processor/Processor.h>
 #include <config/Config.h>
 
 #include <LockGuard.h>
 #include <graphics/Graphics.h>
 #include <graphics/GraphicsService.h>
+
+#include <Service.h>
+#include <ServiceManager.h>
+#include <ServiceFeatures.h>
 
 #include <core/BootIO.h> // In src/system/kernel
 

--- a/src/modules/system/status_server/main.cc
+++ b/src/modules/system/status_server/main.cc
@@ -20,6 +20,7 @@
 #include <Log.h>
 #include <Module.h>
 #include <Version.h>
+#include <machine/Disk.h>
 #include <machine/Network.h>
 #include <processor/Processor.h>
 #include <network-stack/Endpoint.h>

--- a/src/modules/system/usb/UsbDevice.cc
+++ b/src/modules/system/usb/UsbDevice.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -18,7 +17,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <processor/Processor.h>
 #include <utilities/assert.h>
 #include <utilities/PointerGuard.h>
 #include <usb/Usb.h>

--- a/src/modules/system/usb/UsbDevice.h
+++ b/src/modules/system/usb/UsbDevice.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,14 +20,16 @@
 #ifndef USBDEVICE_H
 #define USBDEVICE_H
 
+#include <compiler.h>
 #include <machine/Device.h>
 #include <processor/types.h>
-#include <utilities/assert.h>
 #include <usb/Usb.h>
-#include <usb/UsbDescriptors.h>
 
 class UsbHub;
 class UsbDeviceContainer;
+class UsbEndpointDescriptor;
+class UsbInterfaceDescriptor;
+class UsbDeviceDescriptor;
 
 class UsbDevice
 {

--- a/src/modules/system/usb/UsbHub.cc
+++ b/src/modules/system/usb/UsbHub.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -18,14 +17,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <processor/Processor.h>
 #include <utilities/ExtensibleBitmap.h>
-#include <utilities/PointerGuard.h>
-#include <LockGuard.h>
 #include <usb/Usb.h>
 #include <usb/UsbDevice.h>
 #include <usb/UsbHub.h>
 #include <usb/UsbPnP.h>
+#include <Log.h>
 
 bool UsbHub::deviceConnected(uint8_t nPort, UsbSpeed speed)
 {

--- a/src/modules/system/usb/UsbHub.h
+++ b/src/modules/system/usb/UsbHub.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,7 +21,6 @@
 #define USBHUB_H
 
 #include <machine/Device.h>
-#include <process/Mutex.h>
 #include <process/Semaphore.h>
 #include <processor/types.h>
 #include <utilities/ExtensibleBitmap.h>

--- a/src/modules/system/usb/UsbPnP.cc
+++ b/src/modules/system/usb/UsbPnP.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -18,7 +17,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <processor/Processor.h>
 #include <usb/UsbPnP.h>
 #include <usb/UsbDevice.h>
 

--- a/src/modules/system/usb/UsbPnP.h
+++ b/src/modules/system/usb/UsbPnP.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,7 +20,11 @@
 #ifndef USBPNP_H
 #define USBPNP_H
 
-#include <usb/UsbDevice.h>
+#include <processor/types.h>
+#include <utilities/List.h>
+
+class Device;
+class UsbDevice;
 
 enum UsbPnPConstants
 {

--- a/src/modules/system/users/User.cc
+++ b/src/modules/system/users/User.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,7 +18,6 @@
  */
 
 #include "User.h"
-#include "Group.h"
 #include <process/Process.h>
 #include <processor/Processor.h>
 

--- a/src/modules/system/users/UserManager.cc
+++ b/src/modules/system/users/UserManager.cc
@@ -18,8 +18,9 @@
  */
 
 #include "UserManager.h"
+#include "User.h"
+#include "Group.h"
 #include <Module.h>
-#include <utilities/utility.h>
 #include <process/Process.h>
 #include <processor/Processor.h>
 #include <config/Config.h>

--- a/src/modules/system/users/UserManager.h
+++ b/src/modules/system/users/UserManager.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,8 +20,9 @@
 #include <processor/types.h>
 #include <utilities/Tree.h>
 
-#include "User.h"
-#include "Group.h"
+class Group;
+class String;
+class User;
 
 /** The user manager - this allows lookups of users and groups, and also
     parses the initial file "root:/config/users". */

--- a/src/modules/system/vfs/Directory.h
+++ b/src/modules/system/vfs/Directory.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,7 +22,6 @@
 
 #include <time/Time.h>
 #include <processor/types.h>
-#include <utilities/String.h>
 #include <utilities/RadixTree.h>
 #include "File.h"
 

--- a/src/modules/system/vfs/File.cc
+++ b/src/modules/system/vfs/File.cc
@@ -17,13 +17,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "VFS.h"
 #include "File.h"
-#include "Symlink.h"
 #include "Filesystem.h"
 #include <processor/Processor.h>
 #include <process/Scheduler.h>
 #include <Log.h>
+#include <LockGuard.h>
 
 void File::writeCallback(Cache::CallbackCause cause, uintptr_t loc, uintptr_t page, void *meta)
 {
@@ -393,3 +392,10 @@ String File::getFullPath(bool bWithLabel)
 
     return String(str);
 }
+
+void File::evict(uint64_t location)
+{
+    LockGuard<Mutex> guard(m_Lock);
+    m_DataCache.remove(location);
+}
+

--- a/src/modules/system/vfs/File.h
+++ b/src/modules/system/vfs/File.h
@@ -23,12 +23,13 @@
 #include <time/Time.h>
 #include <processor/types.h>
 #include <utilities/String.h>
-#include <utilities/RadixTree.h>
-#include <process/Thread.h>
-#include <process/Event.h>
 #include <utilities/Cache.h>
 
 #include <processor/PhysicalMemoryManager.h>
+
+class Event;
+class Filesystem;
+class Thread;
 
 #define FILE_UR 0001
 #define FILE_UW 0002
@@ -316,11 +317,7 @@ protected:
      * a way that requires notification from the File subclass when the
      * address returned from readBlock is no longer valid.
      */
-    void evict(uint64_t location)
-    {
-        LockGuard<Mutex> guard(m_Lock);
-        m_DataCache.remove(location);
-    }
+    void evict(uint64_t location);
 
     String m_Name;
     Time m_AccessedTime;

--- a/src/modules/system/vfs/Filesystem.cc
+++ b/src/modules/system/vfs/Filesystem.cc
@@ -17,11 +17,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "VFS.h"
 #include "Filesystem.h"
 #include <Log.h>
 #include <utilities/utility.h>
-#include <processor/Processor.h>
+#include <utilities/RadixTree.h>
+#include <utilities/String.h>
 #include <syscallError.h>
 
 #include "File.h"

--- a/src/modules/system/vfs/Filesystem.h
+++ b/src/modules/system/vfs/Filesystem.h
@@ -22,9 +22,9 @@
 
 #include <processor/types.h>
 #include <utilities/String.h>
-#include <machine/Disk.h>
-#include <vfs/File.h>
-#include <utilities/RadixTree.h>
+
+class Disk;
+class File;
 
 /** This class provides the abstract skeleton that all filesystems must implement.
  *

--- a/src/modules/system/vfs/LockedFile.cc
+++ b/src/modules/system/vfs/LockedFile.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,3 +18,61 @@
  */
 
 #include "LockedFile.h"
+#include "File.h"
+#include <process/Process.h>
+
+LockedFile::LockedFile(File *pFile) : m_File(pFile), m_bLocked(false), m_LockerPid(0), m_Lock(false)
+{}
+
+LockedFile::LockedFile(LockedFile &c) : m_File(0), m_bLocked(false), m_LockerPid(0), m_Lock(false)
+{
+    m_File = c.m_File;
+    m_bLocked = c.m_bLocked;
+    m_LockerPid = c.m_LockerPid;
+
+    if(m_bLocked)
+        m_Lock.acquire();
+}
+
+bool LockedFile::lock(bool bBlock)
+{
+    if(!bBlock)
+    {
+        if(!m_Lock.tryAcquire())
+            return false;
+    }
+    else
+        m_Lock.acquire();
+
+    // Obtained the lock
+    m_bLocked = true;
+    m_LockerPid = Processor::information().getCurrentThread()->getParent()->getId();
+    return true;
+}
+
+void LockedFile::unlock()
+{
+    if(m_bLocked)
+    {
+        m_bLocked = false;
+        m_Lock.release();
+    }
+}
+
+File *LockedFile::getFile()
+{
+    // If we're locked, and we aren't the locking process, we can't access the file
+    // Otherwise, the file is accessible
+    if(m_bLocked == true && Processor::information().getCurrentThread()->getParent()->getId() != m_LockerPid)
+        return 0;
+    else
+        return m_File;
+}
+
+size_t LockedFile::getLocker()
+{
+    if(m_bLocked)
+        return m_LockerPid;
+    else
+        return 0;
+}

--- a/src/modules/system/vfs/LockedFile.h
+++ b/src/modules/system/vfs/LockedFile.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,11 +21,9 @@
 #define LOCKED_FILE_H
 
 #include <processor/types.h>
-#include <process/Scheduler.h>
 #include <process/Mutex.h>
-#include <Log.h>
 
-#include "File.h"
+class File;
 
 /** LockedFile is a wrapper around a standard File with the ability to lock
  * access to it. Locked access is in the form of a Mutex that allows only
@@ -37,73 +34,29 @@ class LockedFile
 public:
 
     /** Standard wrapper constructor */
-    LockedFile(File *pFile) : m_File(pFile), m_bLocked(false), m_LockerPid(0), m_Lock(false)
-    {};
+    LockedFile(File *pFile);
 
     /** Copy constructor */
-    LockedFile(LockedFile &c) : m_File(0), m_bLocked(false), m_LockerPid(0), m_Lock(false)
-    {
-        m_File = c.m_File;
-        m_bLocked = c.m_bLocked;
-        m_LockerPid = c.m_LockerPid;
-
-        if(m_bLocked)
-            m_Lock.acquire();
-    }
+    LockedFile(LockedFile &c);
 
     /** Operator = */
     /// \todo Write me!
     LockedFile & operator = (const LockedFile& c);
 
     /** Attempts to obtain the lock (exclusively) */
-    bool lock(bool bBlock = false)
-    {
-        if(!bBlock)
-        {
-            if(!m_Lock.tryAcquire())
-                return false;
-        }
-        else
-            m_Lock.acquire();
-
-        // Obtained the lock
-        m_bLocked = true;
-        m_LockerPid = Processor::information().getCurrentThread()->getParent()->getId();
-        return true;
-    }
+    bool lock(bool bBlock = false);
 
     /** Releases the lock */
-    void unlock()
-    {
-        if(m_bLocked)
-        {
-            m_bLocked = false;
-            m_Lock.release();
-        }
-    }
+    void unlock();
 
     /** To enforce mandatory locking, use this function to obtain a File to
      * work with. If the file is locked and you don't own the lock, you'll
      * get a NULL File. Otherwise you'll get the wrapped File ready for I/O.
      */
-    File *getFile()
-    {
-        // If we're locked, and we aren't the locking process, we can't access the file
-        // Otherwise, the file is accessible
-        if(m_bLocked == true && Processor::information().getCurrentThread()->getParent()->getId() != m_LockerPid)
-            return 0;
-        else
-            return m_File;
-    }
+    File *getFile();
 
     /** Who's locking the file? */
-    size_t getLocker()
-    {
-        if(m_bLocked)
-            return m_LockerPid;
-        else
-            return 0;
-    }
+    size_t getLocker();
 
 private:
 

--- a/src/modules/system/vfs/MemoryMappedFile.cc
+++ b/src/modules/system/vfs/MemoryMappedFile.cc
@@ -19,11 +19,16 @@
 
 #include "MemoryMappedFile.h"
 
+#include <processor/Processor.h>
 #include <processor/PhysicalMemoryManager.h>
 #include <process/MemoryPressureManager.h>
-#include <Spinlock.h>
+#include <process/Process.h>
+
+#include <vfs/File.h>
 
 #include <utilities/assert.h>
+#include <LockGuard.h>
+#include <Log.h>
 
 MemoryMapManager MemoryMapManager::m_Instance;
 

--- a/src/modules/system/vfs/MemoryMappedFile.h
+++ b/src/modules/system/vfs/MemoryMappedFile.h
@@ -20,15 +20,11 @@
 #ifndef MEMORY_MAPPED_FILE_H
 #define MEMORY_MAPPED_FILE_H
 
-#include "File.h"
-
 #include <processor/PageFaultHandler.h>
 #include <process/MemoryPressureManager.h>
 #include <utilities/Tree.h>
 #include <utilities/List.h>
 #include <process/Mutex.h>
-#include <process/Process.h>
-#include <LockGuard.h>
 
 /** \addtogroup vfs
     @{ */
@@ -94,7 +90,9 @@
     
     \todo Handle writing of files, not just reading. */
 
-class MemoryMapManager;
+class File;
+class Process;
+class VirtualAddressSpace;
 
 /**
  * Generic base for a memory mapped file or object.

--- a/src/modules/system/vfs/Pipe.cc
+++ b/src/modules/system/vfs/Pipe.cc
@@ -18,7 +18,6 @@
  */
 
 #include "Pipe.h"
-#include "Filesystem.h"
 #include <utilities/ZombieQueue.h>
 
 class ZombiePipe : public ZombieObject

--- a/src/modules/system/vfs/Pipe.h
+++ b/src/modules/system/vfs/Pipe.h
@@ -22,14 +22,10 @@
 
 #include <time/Time.h>
 #include <processor/types.h>
-#include <utilities/String.h>
-#include <utilities/RadixTree.h>
 #include <process/Semaphore.h>
 #include "File.h"
 
 #define PIPE_BUF_MAX 2048
-
-class ZombiePipe;
 
 /** A first-in-first-out buffer node. */
 class Pipe : public File

--- a/src/modules/system/vfs/Symlink.h
+++ b/src/modules/system/vfs/Symlink.h
@@ -23,7 +23,6 @@
 #include <time/Time.h>
 #include <processor/types.h>
 #include <utilities/String.h>
-#include <utilities/RadixTree.h>
 #include "File.h"
 
 /** A symbolic link node. */

--- a/src/modules/system/vfs/VFS.cc
+++ b/src/modules/system/vfs/VFS.cc
@@ -18,9 +18,10 @@
  */
 
 #include "VFS.h"
-#include <Log.h>
+#include "File.h"
 #include <Module.h>
 #include <utilities/utility.h>
+#include <utilities/StaticString.h>
 
 /// \todo Figure out a way to clean up files after deletion. Directory::remove()
 ///       is not the right place to do this. There needs to be a way to add a

--- a/src/modules/system/vfs/VFS.h
+++ b/src/modules/system/vfs/VFS.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,6 +22,8 @@
 
 #include <processor/types.h>
 #include <utilities/List.h>
+#include <utilities/Tree.h>
+#include <utilities/RadixTree.h>
 #include <utilities/String.h>
 #include "Filesystem.h"
 

--- a/src/subsys/native/kernel/NativeIpc.cc
+++ b/src/subsys/native/kernel/NativeIpc.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,6 +18,7 @@
  */
 
 #include <process/Ipc.h>
+#include <process/Process.h>
 #include <ipc/Ipc.h>
 
 #include <utilities/Tree.h>

--- a/src/subsys/pedigree-c/pedigree-syscalls.cc
+++ b/src/subsys/pedigree-c/pedigree-syscalls.cc
@@ -25,14 +25,22 @@
 #include <vfs/VFS.h>
 #include <Log.h>
 #include <syscallError.h>
+#include <process/Process.h>
 
+#include <machine/Display.h>
+#include <machine/Framebuffer.h>
 #include <machine/InputManager.h>
 #include <machine/KeymapManager.h>
 
 #include <graphics/Graphics.h>
 #include <graphics/GraphicsService.h>
 
+#include <Service.h>
+#include <ServiceManager.h>
+#include <ServiceFeatures.h>
+
 #include <users/UserManager.h>
+#include <users/User.h>
 
 #define PEDIGREEC_WITHIN_KERNEL
 #include "pedigree-syscalls.h"

--- a/src/subsys/posix/DevFs.cc
+++ b/src/subsys/posix/DevFs.cc
@@ -22,12 +22,18 @@
 #define MACHINE_FORWARD_DECL_ONLY
 #include <machine/Machine.h>
 #include <machine/Vga.h>
+#include <machine/Display.h>
 
 #include <console/Console.h>
 #include <utilities/assert.h>
 
+#include <machine/Framebuffer.h>
 #include <graphics/Graphics.h>
 #include <graphics/GraphicsService.h>
+
+#include <Service.h>
+#include <ServiceManager.h>
+#include <ServiceFeatures.h>
 
 #include <utilities/utility.h>
 

--- a/src/subsys/posix/PosixSubsystem.cc
+++ b/src/subsys/posix/PosixSubsystem.cc
@@ -53,6 +53,39 @@ RadixTree<LockedFile*> g_PosixGlobalLockedFiles;
 
 ProcessGroupManager ProcessGroupManager::m_Instance;
 
+ProcessGroupManager::ProcessGroupManager() : m_GroupIds()
+{
+    m_GroupIds.set(0);
+}
+
+ProcessGroupManager::~ProcessGroupManager()
+{
+}
+
+size_t ProcessGroupManager::allocateGroupId()
+{
+    size_t bit = m_GroupIds.getFirstClear();
+    m_GroupIds.set(bit);
+    return bit;
+}
+
+void ProcessGroupManager::setGroupId(size_t gid)
+{
+    if(m_GroupIds.test(gid))
+        WARNING("ProcessGroupManager: setGroupId called on a group ID that existed already!");
+    m_GroupIds.set(gid);
+}
+
+bool ProcessGroupManager::isGroupIdValid(size_t gid)
+{
+    return m_GroupIds.test(gid);
+}
+
+void ProcessGroupManager::returnGroupId(size_t gid)
+{
+    m_GroupIds.clear(gid);
+}
+
 /// Default constructor
 FileDescriptor::FileDescriptor() :
     file(0), offset(0), fd(0xFFFFFFFF), fdflags(0), flflags(0),

--- a/src/subsys/posix/PosixSubsystem.h
+++ b/src/subsys/posix/PosixSubsystem.h
@@ -69,12 +69,9 @@ extern RadixTree<LockedFile*> g_PosixGlobalLockedFiles;
 class ProcessGroupManager
 {
     public:
-        ProcessGroupManager() : m_GroupIds()
-        {
-            m_GroupIds.set(0);
-        }
+        ProcessGroupManager();
 
-        virtual ~ProcessGroupManager() {}
+        virtual ~ProcessGroupManager();
 
         static ProcessGroupManager &instance()
         {
@@ -82,32 +79,16 @@ class ProcessGroupManager
         }
 
         /** Allocates a new process group ID, that hasn't yet been used. */
-        size_t allocateGroupId()
-        {
-            size_t bit = m_GroupIds.getFirstClear();
-            m_GroupIds.set(bit);
-            return bit;
-        }
+        size_t allocateGroupId();
 
         /** Forcibly set the given group ID as taken. */
-        void setGroupId(size_t gid)
-        {
-            if(m_GroupIds.test(gid))
-                WARNING("ProcessGroupManager: setGroupId called on a group ID that existed already!");
-            m_GroupIds.set(gid);
-        }
+        void setGroupId(size_t gid);
 
         /** Checks whether the given process group ID is used or not. */
-        bool isGroupIdValid(size_t gid)
-        {
-            return m_GroupIds.test(gid);
-        }
+        bool isGroupIdValid(size_t gid);
 
         /** Returns the given process group ID to the available pool. */
-        void returnGroupId(size_t gid)
-        {
-            m_GroupIds.clear(gid);
-        }
+        void returnGroupId(size_t gid);
 
     private:
         static ProcessGroupManager m_Instance;

--- a/src/subsys/posix/console-syscalls.cc
+++ b/src/subsys/posix/console-syscalls.cc
@@ -21,6 +21,7 @@
 #include <processor/types.h>
 #include <processor/Processor.h>
 #include <process/Process.h>
+#include <process/Scheduler.h>
 #include <utilities/Tree.h>
 #include <vfs/File.h>
 #include <vfs/VFS.h>

--- a/src/subsys/posix/file-syscalls.cc
+++ b/src/subsys/posix/file-syscalls.cc
@@ -35,6 +35,7 @@
 #include <network-stack/NetManager.h>
 #include <network-stack/Tcp.h>
 #include <utilities/utility.h>
+#include <machine/Disk.h>
 
 #include <Subsystem.h>
 #include <PosixSubsystem.h>

--- a/src/subsys/posix/pthread-syscalls.cc
+++ b/src/subsys/posix/pthread-syscalls.cc
@@ -18,10 +18,12 @@
  */
 
 #include <process/Scheduler.h>
+#include <process/Process.h>
 #include <pthread-syscalls.h>
 #include <syscallError.h>
 #include "errors.h"
 #include "PosixSubsystem.h"
+#include <Log.h>
 
 extern "C"
 {

--- a/src/subsys/posix/sem-syscalls.cc
+++ b/src/subsys/posix/sem-syscalls.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -24,7 +23,9 @@
 #include "errors.h"
 
 #include <process/Semaphore.h>
+#include <process/Process.h>
 #include <process/Mutex.h>
+#include <Log.h>
 
 int posix_sem_close(sem_t *sem)
 {

--- a/src/subsys/posix/system-syscalls.cc
+++ b/src/subsys/posix/system-syscalls.cc
@@ -53,6 +53,8 @@
 #include <PosixProcess.h>
 
 #include <users/UserManager.h>
+#include <users/User.h>
+#include <users/Group.h>
 #include <console/Console.h>
 
 //

--- a/src/system/include/Log.h
+++ b/src/system/include/Log.h
@@ -25,6 +25,7 @@
 #include <utilities/String.h>
 #include <utilities/Vector.h>
 #include <utilities/StaticString.h>
+#include <processor/Processor.h>
 #include <panic.h>
 
 /** @addtogroup kernel

--- a/src/system/include/ServiceManager.h
+++ b/src/system/include/ServiceManager.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,11 +20,11 @@
 #ifndef SERVICE_MANAGER_H
 #define SERVICE_MANAGER_H
 
-#include <processor/types.h>
 #include <utilities/RadixTree.h>
 
-#include <Service.h>
-#include <ServiceFeatures.h>
+class Service;
+class ServiceFeatures;
+class String;
 
 /// \todo Integrate with the Event system somehow
 

--- a/src/system/include/Subsystem.h
+++ b/src/system/include/Subsystem.h
@@ -26,8 +26,6 @@ class Thread;
 #include <processor/state.h>
 class Process;
 
-#include <Log.h>
-
 /** The abstract base class for a generic application subsystem. This provides
   * a well-defined interface to the kernel that allows global behaviour to have
   * correct results on different applications. This also allows the kernel to
@@ -109,19 +107,13 @@ class Subsystem
         virtual void threadException(Thread *pThread, ExceptionType eType);
 
         /** Gets the type of this subsystem */
-        SubsystemType getType()
+        SubsystemType getType() const
         {
             return m_Type;
         }
 
         /** Sets the process that this subsystem is linked to. */
-        virtual void setProcess(Process *p)
-        {
-            if(!m_pProcess)
-                m_pProcess = p;
-            else
-                WARNING("An attempt was made to change the Process of a Subsystem!");
-        }
+        virtual void setProcess(Process *p);
 
     protected:
 

--- a/src/system/include/graphics/GraphicsService.h
+++ b/src/system/include/graphics/GraphicsService.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,10 +21,11 @@
 #define _GRAPHICS_SERVICE_H
 
 #include <processor/types.h>
-#include <ServiceManager.h>
+#include <Service.h>
+#include <utilities/List.h>
 
-#include <machine/Framebuffer.h>
-#include <machine/Display.h>
+class Display;
+class Framebuffer;
 
 class GraphicsService : public Service
 {

--- a/src/system/include/linker/KernelElf.h
+++ b/src/system/include/linker/KernelElf.h
@@ -23,7 +23,6 @@
 #include <linker/Elf.h>
 #include <compiler.h>
 #include <processor/MemoryRegion.h>
-#include <BootstrapInfo.h>
 #include <utilities/Vector.h>
 #include <utilities/MemoryAllocator.h>
 

--- a/src/system/include/machine/Device.h
+++ b/src/system/include/machine/Device.h
@@ -23,11 +23,11 @@
 #include <utilities/String.h>
 #include <utilities/Vector.h>
 #include <processor/types.h>
-#include <processor/IoBase.h>
-#include <Log.h>
 #ifdef OPENFIRMWARE
 #include <machine/openfirmware/OpenFirmware.h>
 #endif
+
+class IoBase;
 
 /**
  * Represents a node in the device tree. This could either be a bus (non-leaf node) or a

--- a/src/system/include/machine/DeviceHashTree.h
+++ b/src/system/include/machine/DeviceHashTree.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,8 +21,9 @@
 #define _MACHINE_DEVICE_HASH_TREE_H
 
 #include <utilities/Tree.h>
-#include <utilities/String.h>
+
 class Device;
+class String;
 
 /**
  * DeviceHashTree: Name-based device access

--- a/src/system/include/machine/Framebuffer.h
+++ b/src/system/include/machine/Framebuffer.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -25,8 +24,6 @@
 #include <utilities/utility.h>
 #include <graphics/Graphics.h>
 #include <Log.h>
-
-class Display;
 
 /** This class provides a generic interface for interfacing with a framebuffer.
  *  Each display driver specialises this class to define the "base address" of

--- a/src/system/include/machine/HidInputManager.h
+++ b/src/system/include/machine/HidInputManager.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,10 +20,9 @@
 #ifndef MACHINE_HID_INPUT_MANAGER_H
 #define MACHINE_HID_INPUT_MANAGER_H
 
-#include <processor/Processor.h>
 #include <processor/types.h>
+#include <machine/TimerHandler.h>
 #include <utilities/Tree.h>
-#include <machine/Timer.h>
 #include <Spinlock.h>
 
 /**

--- a/src/system/include/machine/InputManager.h
+++ b/src/system/include/machine/InputManager.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,7 +20,6 @@
 #ifndef MACHINE_INPUT_MANAGER_H
 #define MACHINE_INPUT_MANAGER_H
 
-#include <processor/Processor.h>
 #include <processor/types.h>
 #include <utilities/List.h>
 #include <process/Semaphore.h>

--- a/src/system/include/machine/KeymapManager.h
+++ b/src/system/include/machine/KeymapManager.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,8 +20,9 @@
 #ifndef MACHINE_KEYMAP_MANAGER_H
 #define MACHINE_KEYMAP_MANAGER_H
 
-#include <processor/Processor.h>
 #include <processor/types.h>
+#include <utilities/Tree.h>
+#include <Spinlock.h>
 
 /**
  * Global manager for keymaps

--- a/src/system/include/machine/Network.h
+++ b/src/system/include/machine/Network.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,16 +21,15 @@
 #define MACHINE_NETWORK_H
 
 #include <processor/types.h>
-#include <processor/state.h>
 #include <machine/Device.h>
-#include <utilities/utility.h>
 
 #include "../../kernel/core/BootIO.h"
 extern BootIO bootIO;
 
 #include <network/IpAddress.h>
 #include <network/MacAddress.h>
-#include <network/NetworkBlockTimeout.h>
+
+#include <Log.h>
 
 /** Station information - basically information about this station, per NIC */
 class StationInfo

--- a/src/system/include/network/IpAddress.h
+++ b/src/system/include/network/IpAddress.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -24,7 +23,6 @@
 #include <processor/types.h>
 #include <utilities/utility.h>
 
-#include <utilities/StaticString.h>
 #include <utilities/String.h>
 
 /** An IPv4/IPv6 address */

--- a/src/system/include/network/NetworkBlockTimeout.h
+++ b/src/system/include/network/NetworkBlockTimeout.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,11 +21,6 @@
 #define NETWORK_BLOCK_TIMEOUT_H
 
 #include <processor/types.h>
-
-#define MACHINE_FORWARD_DECL_ONLY
-#include <machine/Machine.h>
-#include <machine/Timer.h>
-#undef MACHINE_FORWARD_DECL_ONLY
 
 #include <process/Semaphore.h>
 #include <Log.h>

--- a/src/system/include/process/Ipc.h
+++ b/src/system/include/process/Ipc.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,8 +21,6 @@
 #define _PROCESS_IPC_H
 
 #include <processor/types.h>
-#include <processor/Processor.h>
-#include <processor/MemoryRegion.h>
 
 #include <process/Semaphore.h>
 #include <process/Mutex.h>

--- a/src/system/include/process/LockManager.h
+++ b/src/system/include/process/LockManager.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,8 +20,9 @@
 #ifndef LOCK_MANAGER_H
 #define LOCK_MANAGER_H
 
-#include <process/Semaphore.h>
 #include <utilities/Vector.h>
+
+class Semaphore;
 
 /**
  * A class for managing locks. It is only used if ENFORCE_LOCK_ORDERING is defined,

--- a/src/system/include/process/PerProcessorScheduler.h
+++ b/src/system/include/process/PerProcessorScheduler.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -27,13 +26,9 @@
 #include <processor/state.h>
 #include <machine/TimerHandler.h>
 #include <process/Mutex.h>
-#include <process/Process.h>
 #include <process/Thread.h>
-#include <Atomic.h>
 
 class SchedulingAlgorithm;
-class Processor;
-class Thread;
 class Spinlock;
 
 class PerProcessorScheduler : public TimerHandler

--- a/src/system/include/process/ProcessorThreadAllocator.h
+++ b/src/system/include/process/ProcessorThreadAllocator.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,11 +20,9 @@
 #ifndef _PROCESSOR_THREAD_ALLOCATOR_H
 #define _PROCESSOR_THREAD_ALLOCATOR_H
 
-#include <process/ThreadToCoreAllocationAlgorithm.h>
-#include <process/PerProcessorScheduler.h>
 #include <process/Thread.h>
 
-#include <processor/types.h>
+class ThreadToCoreAllocationAlgorithm;
 
 class ProcessorThreadAllocator
 {

--- a/src/system/include/process/RoundRobinCoreAllocator.h
+++ b/src/system/include/process/RoundRobinCoreAllocator.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,6 +21,8 @@
 #define ROUND_ROBIN_CORE_ALLOCATOR_H
 
 #include <process/ThreadToCoreAllocationAlgorithm.h>
+#include <utilities/List.h>
+#include <utilities/Tree.h>
 
 class RoundRobinCoreAllocator : public ThreadToCoreAllocationAlgorithm
 {
@@ -32,38 +33,9 @@ class RoundRobinCoreAllocator : public ThreadToCoreAllocationAlgorithm
         virtual ~RoundRobinCoreAllocator()
         {}
         
-        virtual bool initialise(List<PerProcessorScheduler*> &procList)
-        {
-            List<PerProcessorScheduler*>::Iterator it = procList.begin();
-            PerProcessorScheduler *pFirst = m_pNext = *it;
-            it++;
-            
-            // 1 CPU?
-            if(it == procList.end())
-            {
-                NOTICE("Quitting, only one CPU was present.");
-                m_ProcMap.insert(pFirst, pFirst);
-                return true;
-            }
-            
-            for(; it != procList.end(); it++)
-            {
-                m_ProcMap.insert(pFirst, *it);
-                pFirst = *it;
-            }
-            
-            // Loop.
-            m_ProcMap.insert(pFirst, m_pNext);
-            
-            return true;
-        }
+        virtual bool initialise(List<PerProcessorScheduler*> &procList);
         
-        virtual PerProcessorScheduler* allocateThread(Thread *pThread)
-        {
-            PerProcessorScheduler *pReturn = m_ProcMap.lookup(m_pNext);
-            m_pNext = pReturn;
-            return pReturn;
-        }
+        virtual PerProcessorScheduler* allocateThread(Thread *pThread);
     
     private:
     

--- a/src/system/include/process/Scheduler.h
+++ b/src/system/include/process/Scheduler.h
@@ -22,15 +22,15 @@
 
 #ifdef THREADS
 
-#include <process/PerProcessorScheduler.h>
 #include <processor/types.h>
-#include <processor/state.h>
-#include <machine/TimerHandler.h>
-#include <process/Mutex.h>
-#include <process/Process.h>
 #include <Atomic.h>
 
+#include <utilities/List.h>
+#include <utilities/Tree.h>
+
+class PerProcessorScheduler;
 class Thread;
+class Process;
 class Processor;
 
 /** \brief This class manages how processes and threads are scheduled across processors.

--- a/src/system/include/process/Thread.h
+++ b/src/system/include/process/Thread.h
@@ -22,8 +22,6 @@
 
 #ifdef THREADS
 
-#include <Log.h>
-
 #include <processor/state.h>
 #include <processor/types.h>
 #include <process/Event.h>
@@ -32,14 +30,7 @@
 #include <utilities/RequestQueue.h>
 #include <utilities/ExtensibleBitmap.h>
 
-#include <processor/MemoryRegion.h>
-
-// Hacky but I'd rather not c&p the typedef
-#define _PROCESSOR_INFORMATION_ONLY_WANT_PROCESSORID
-#include <processor/ProcessorInformation.h>
-#undef _PROCESSOR_INFORMATION_ONLY_WANT_PROCESSORID
-
-class Processor;
+class MemoryRegion;
 class Process;
 
 /** Thread TLS area size */
@@ -124,45 +115,20 @@ public:
     /** Returns a reference to the Thread's saved context. This function is intended only
      * for use by the Scheduler. */
     SchedulerState &state()
-    {return m_StateLevels[m_nStateLevel].m_State;}
+    {
+        return m_StateLevels[m_nStateLevel].m_State;
+    }
 
     /** Increases the state nesting level by one - pushes a new state to the top of the state stack.
         This also pushes to the top of the inhibited events stack, copying the current inhibit mask.
         \todo This should also push errno and m_bInterrupted, so syscalls can be
               used safely in interrupt handlers.
         \return A reference to the previous state. */
-    SchedulerState &pushState()
-    {
-        if ((m_nStateLevel + 1) >= MAX_NESTED_EVENTS)
-        {
-            ERROR("Thread: Max nested events!");
-            /// \todo Take some action here - possibly kill the thread?
-            return m_StateLevels[MAX_NESTED_EVENTS - 1].m_State;
-        }
-        m_nStateLevel++;
-        // NOTICE("New state level: " << m_nStateLevel << "...");
-        m_StateLevels[m_nStateLevel].m_InhibitMask = m_StateLevels[m_nStateLevel - 1].m_InhibitMask;
-        allocateStackAtLevel(m_nStateLevel);
-
-        setKernelStack();
-
-        return m_StateLevels[m_nStateLevel - 1].m_State;
-    }
+    SchedulerState &pushState();
 
     /** Decreases the state nesting level by one, popping both the state stack and the inhibit mask
         stack.*/
-    void popState()
-    {
-        if (m_nStateLevel == 0)
-        {
-            ERROR("Thread: Potential error: popStack() called with state level 0!");
-            ERROR("Thread: (ignore this if longjmp has been called)");
-            return;
-        }
-        m_nStateLevel --;
-
-        setKernelStack();
-    }
+    void popState();
 
     void *getStateUserStack()
     {
@@ -189,57 +155,67 @@ public:
      *\param stateLevel The nesting level to edit.
      *\param state The state to copy.
      */
-    void pokeState(size_t stateLevel, SchedulerState &state)
-    {
-        if (stateLevel >= MAX_NESTED_EVENTS)
-        {
-            ERROR("Thread::pokeState(): stateLevel `" << stateLevel << "' is over the maximum.");
-            return;
-        }
-        m_StateLevels[stateLevel].m_State = state;
-    }
+    void pokeState(size_t stateLevel, SchedulerState &state);
 
     /** Retrieves a pointer to this Thread's parent process. */
     Process *getParent() const
-    {return m_pParent;}
+    {
+        return m_pParent;
+    }
 
     void setParent(Process *p)
-    {m_pParent = p;}
+    {
+        m_pParent = p;
+    }
 
     /** Retrieves our current status. */
     Status getStatus() const
-    {return m_Status;}
+    {
+        return m_Status;
+    }
 
     /** Sets our current status. */
     void setStatus(Status s);
 
     /** Retrieves the exit status of the Thread. */
     int getExitCode()
-    {return m_ExitCode;}
+    {
+        return m_ExitCode;
+    }
 
     /** Retrieves a pointer to the top of the Thread's kernel stack. */
     void *getKernelStack();
 
     /** Returns the Thread's ID. */
     size_t getId()
-    {return m_Id;}
+    {
+        return m_Id;
+    }
 
     /** Returns the last error that occurred (errno). */
     size_t getErrno()
-    {return m_Errno;}
+    {
+        return m_Errno;
+    }
 
     /** Sets the last error - errno. */
     void setErrno(size_t errno)
-    {m_Errno = errno;}
+    {
+        m_Errno = errno;
+    }
 
     /** Returns whether the thread was just interrupted deliberately (e.g.
         because of a timeout). */
     bool wasInterrupted()
-    {return m_bInterrupted;}
+    {
+        return m_bInterrupted;
+    }
 
     /** Sets whether the thread was just interrupted deliberately. */
     void setInterrupted(bool b)
-    {m_bInterrupted = b;}
+    {
+        m_bInterrupted = b;
+    }
 
     /** Enum used by the following function. */
     enum UnwindType

--- a/src/system/include/process/ThreadToCoreAllocationAlgorithm.h
+++ b/src/system/include/process/ThreadToCoreAllocationAlgorithm.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,8 +20,9 @@
 #ifndef _THREAD_TO_CORE_ALLOCATION_ALGORITHM_H
 #define _THREAD_TO_CORE_ALLOCATION_ALGORITHM_H
 
-#include <process/Thread.h>
-#include <process/PerProcessorScheduler.h>
+class PerProcessorScheduler;
+class Thread;
+template <class T> class List;
 
 /// \todo Document.
 

--- a/src/system/include/processor/IoPort.h
+++ b/src/system/include/processor/IoPort.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,7 +22,6 @@
 
 #include <processor/types.h>
 #include <processor/IoBase.h>
-#include <utilities/String.h>
 
 /** @addtogroup kernelprocessor
  * @{ */

--- a/src/system/include/processor/KernelCoreSyscallManager.h
+++ b/src/system/include/processor/KernelCoreSyscallManager.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,6 +22,8 @@
 
 #include <processor/types.h>
 #include <processor/SyscallHandler.h>
+
+class Process;
 
 class KernelCoreSyscallManager : public SyscallHandler
 {

--- a/src/system/include/processor/PageFaultHandler.h
+++ b/src/system/include/processor/PageFaultHandler.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,6 +21,7 @@
 #define KERNEL_CORE_PROCESSOR_PAGEFAULTHANDLER_H_
 
 #include <processor/InterruptManager.h>
+#include <utilities/List.h>
 
 /** @addtogroup kernelprocessor
  * @{ */
@@ -52,8 +52,7 @@ public:
     bool initialise();
 
     /** Registers a trap handler. */
-    void registerHandler(MemoryTrapHandler *pHandler)
-      {m_Handlers.pushBack(pHandler);}
+    void registerHandler(MemoryTrapHandler *pHandler);
 
     //
     // InterruptHandler interface.

--- a/src/system/include/processor/PhysicalMemoryManager.h
+++ b/src/system/include/processor/PhysicalMemoryManager.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,7 +20,6 @@
 #ifndef KERNEL_PROCESSOR_PHYSICALMEMORYMANAGER_H
 #define KERNEL_PROCESSOR_PHYSICALMEMORYMANAGER_H
 
-#include <compiler.h>
 #include <utilities/Vector.h>
 #include <processor/types.h>
 

--- a/src/system/include/processor/Processor.h
+++ b/src/system/include/processor/Processor.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,16 +21,15 @@
 #define KERNEL_PROCESSOR_PROCESSOR_H
 
 #include <compiler.h>
-#include <BootstrapInfo.h>
-#include <utilities/Vector.h>
 #include <utilities/StaticString.h>
 #include <processor/types.h>
 #include <processor/state.h>
-#include <processor/VirtualAddressSpace.h>
 #include <processor/ProcessorInformation.h>
 
 /** @addtogroup kernelprocessor
  * @{ */
+
+struct BootstrapStruct_t;
 
 namespace DebugFlags
 {

--- a/src/system/include/processor/StackFrame.h
+++ b/src/system/include/processor/StackFrame.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,8 +19,6 @@
 
 #ifndef KERNEL_PROCESSOR_STACKFRAME_H
 #define KERNEL_PROCESSOR_STACKFRAME_H
-
-#include <processor/StackFrameBase.h>
 
 #if defined(X86)
   #include <processor/x86/StackFrame.h>

--- a/src/system/include/processor/x64/Processor.h
+++ b/src/system/include/processor/x64/Processor.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,7 +19,5 @@
 
 #ifndef KERNEL_PROCESSOR_X64_PROCESSOR_H
 #define KERNEL_PROCESSOR_X64_PROCESSOR_H
-
-#include <Log.h>
 
 #endif

--- a/src/system/include/processor/x64/StackFrame.h
+++ b/src/system/include/processor/x64/StackFrame.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,6 +22,7 @@
 
 #include <compiler.h>
 #include <processor/types.h>
+#include <processor/StackFrameBase.h>
 
 /** @addtogroup kernelprocessorx64
  * @{ */

--- a/src/system/include/processor/x64/state.h
+++ b/src/system/include/processor/x64/state.h
@@ -214,7 +214,7 @@ class X64SyscallState
      *\return the syscall function number */
     inline size_t getSyscallNumber() const;
     /** Get the n'th parameter for this syscall. */
-    inline uintptr_t getSyscallParameter(size_t n) const;
+    uintptr_t getSyscallParameter(size_t n) const;
     inline void setSyscallReturnValue(uintptr_t val);
     inline void setSyscallErrno(uintptr_t val);
 

--- a/src/system/include/processor/x64/state.h
+++ b/src/system/include/processor/x64/state.h
@@ -22,7 +22,6 @@
 
 #include <compiler.h>
 #include <processor/types.h>
-#include <Log.h>
 
 /** @addtogroup kernelprocessorx64
  * @{ */
@@ -447,20 +446,6 @@ size_t X64SyscallState::getSyscallService() const
 size_t X64SyscallState::getSyscallNumber() const
 {
   return (m_Rax & 0xFFFF);
-}
-uintptr_t X64SyscallState::getSyscallParameter(size_t n) const
-{
-  switch (n)
-  {
-    case 0: return m_Rbx;
-    case 1: return m_Rdx;
-    case 2: return m_Rsi;
-    case 3: return m_Rdi;
-    case 4: return m_R8;
-    default:
-      WARNING("Bad syscall parameter requested: " << Dec << n);
-      return 0;
-  }
 }
 void X64SyscallState::setSyscallReturnValue(uintptr_t val)
 {

--- a/src/system/include/utilities/RadixTree.h
+++ b/src/system/include/utilities/RadixTree.h
@@ -24,8 +24,7 @@
 #include <utilities/String.h>
 #include <utilities/Iterator.h>
 #include <utilities/IteratorAdapter.h>
-#include <Log.h>
-#include <processor/Processor.h>
+#include <utilities/Vector.h>
 
 /**\file  RadixTree.h
  *\author James Molloy <jamesm@osdev.org>

--- a/src/system/include/utilities/RingBuffer.h
+++ b/src/system/include/utilities/RingBuffer.h
@@ -22,7 +22,6 @@
 
 #include <processor/types.h>
 #include <process/Semaphore.h>
-#include <process/Event.h>
 #include <process/Mutex.h>
 #include <utilities/List.h>
 

--- a/src/system/include/utilities/TimeoutGuard.h
+++ b/src/system/include/utilities/TimeoutGuard.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -28,9 +27,9 @@
           a given amount of time. */
 
 #include <processor/types.h>
+#include <processor/state.h>
 #include <process/Event.h>
 #include <process/eventNumbers.h>
-#include <process/PerProcessorScheduler.h>
 #include <Spinlock.h>
 
 /** This class waits (in the background) for a given amount of time to elapse,

--- a/src/system/include/utilities/Tree.h
+++ b/src/system/include/utilities/Tree.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,10 +22,6 @@
 
 #include <processor/types.h>
 #include <utilities/Iterator.h>
-
-#include <Log.h>
-
-#include <new>
 
 /** @addtogroup kernelutilities
  * @{ */
@@ -151,7 +146,6 @@ class Tree
     {
         if(count())
         {
-            ERROR("Tree: probable leak, Tree destructor called with items in tree.");
             clear();
         }
         delete m_Begin;

--- a/src/system/include/utilities/UnlikelyLock.h
+++ b/src/system/include/utilities/UnlikelyLock.h
@@ -20,8 +20,6 @@
 #ifndef UNLIKELY_LOCK_H
 #define UNLIKELY_LOCK_H
 
-#include <processor/Processor.h>
-#include <process/Scheduler.h>
 #include <process/Semaphore.h>
 
 /** \file UnlikelyLock.h

--- a/src/system/include/utilities/ZombieQueue.h
+++ b/src/system/include/utilities/ZombieQueue.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,7 +22,6 @@
 
 #include <processor/types.h>
 #include <utilities/RequestQueue.h>
-#include <Log.h>
 
 #include <process/Process.h>
 

--- a/src/system/include/utilities/assert.h
+++ b/src/system/include/utilities/assert.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,6 +19,8 @@
 
 #ifndef KERNEL_ASSERT_H
 #define KERNEL_ASSERT_H
+
+#include <processor/types.h>
 
 /** @addtogroup kernel
  * @{ */

--- a/src/system/kernel/Log.cc
+++ b/src/system/kernel/Log.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,11 +19,8 @@
 
 #include <BootstrapInfo.h>
 #include <Log.h>
-#include <panic.h>
 #include <machine/Timer.h>
 #include <machine/Machine.h>
-#include <utilities/utility.h>
-#include <processor/Processor.h>
 #include <LockGuard.h>
 
 extern BootstrapStruct_t *g_pBootstrapInfo;

--- a/src/system/kernel/Spinlock.cc
+++ b/src/system/kernel/Spinlock.cc
@@ -19,7 +19,6 @@
 
 #include <Spinlock.h>
 #include <processor/Processor.h>
-#include <process/Thread.h>
 
 #ifdef TRACK_LOCKS
 #include <LocksCommand.h>
@@ -28,6 +27,8 @@
 #include <Log.h>
 
 #include <panic.h>
+
+class Thread;
 
 bool Spinlock::acquire()
 {

--- a/src/system/kernel/Subsystem.cc
+++ b/src/system/kernel/Subsystem.cc
@@ -19,8 +19,8 @@
 
 #include <Log.h>
 #include <Subsystem.h>
-#include <process/Thread.h>
-#include <processor/Processor.h>
+
+class Thread;
 
 bool Subsystem::kill(KillReason killReason, Thread *pThread)
 {
@@ -37,4 +37,12 @@ void Subsystem::exit(int code)
 void Subsystem::threadException(Thread *pThread, ExceptionType eType)
 {
     FATAL("Subsystem::threadException - not overridden");
+}
+
+void Subsystem::setProcess(Process *p)
+{
+    if(!m_pProcess)
+        m_pProcess = p;
+    else
+        WARNING("An attempt was made to change the Process of a Subsystem!");
 }

--- a/src/system/kernel/config/ConfigurationBackend.cc
+++ b/src/system/kernel/config/ConfigurationBackend.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,8 +19,6 @@
 
 #include <config/ConfigurationManager.h>
 #include <config/ConfigurationBackend.h>
-
-#include <processor/types.h>
 
 ConfigurationBackend::ConfigurationBackend(String configStore) :
     m_ConfigStore(configStore)

--- a/src/system/kernel/core/BootIO.h
+++ b/src/system/kernel/core/BootIO.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,7 +21,8 @@
 #define BOOTIO_H
 
 #include <utilities/StaticString.h>
-#include <machine/Serial.h>
+
+class Serial;
 
 /**
  * A class which provides *extremely* simple output to both the Vga class and Serial classes,

--- a/src/system/kernel/core/BootstrapInfo.cc
+++ b/src/system/kernel/core/BootstrapInfo.cc
@@ -19,7 +19,6 @@
 
 #include <compiler.h>
 #include <processor/types.h>
-#include <utilities/String.h>
 
 #include <BootstrapInfo.h>
 

--- a/src/system/kernel/core/KernelCoreSyscallManager.cc
+++ b/src/system/kernel/core/KernelCoreSyscallManager.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,7 +19,6 @@
 
 #include <processor/KernelCoreSyscallManager.h>
 #include <processor/SyscallManager.h>
-#include <processor/Processor.h>
 #include <process/Scheduler.h>
 #include <Log.h>
 

--- a/src/system/kernel/core/lib/SlamAllocator.cc
+++ b/src/system/kernel/core/lib/SlamAllocator.cc
@@ -20,17 +20,12 @@
 #include "SlamAllocator.h"
 
 #include <utilities/assert.h>
-#include <utilities/MemoryTracing.h>
 #include <LockGuard.h>
 
-#include <machine/Machine.h>
 #include <processor/Processor.h>
 #include <processor/VirtualAddressSpace.h>
 #include <processor/PhysicalMemoryManager.h>
 #include <panic.h>
-
-#include <Backtrace.h>
-#include <SlamCommand.h>
 
 #define TEMP_MAGIC 0x67845753
 

--- a/src/system/kernel/core/lib/SlamAllocator.h
+++ b/src/system/kernel/core/lib/SlamAllocator.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -28,9 +27,7 @@
 **/
 
 #include <processor/types.h>
-#include <processor/PhysicalMemoryManager.h>
 #include <utilities/MemoryAllocator.h>
-#include <Log.h>
 
 #include <Spinlock.h>
 

--- a/src/system/kernel/core/lib/cppsupport.cc
+++ b/src/system/kernel/core/lib/cppsupport.cc
@@ -18,17 +18,11 @@
  */
 
 #include <processor/types.h>
-#include <Spinlock.h>
 #include "cppsupport.h"
 #include <panic.h>
-#include <processor/Processor.h>
-#include <processor/PhysicalMemoryManager.h>
-#include <processor/VirtualAddressSpace.h>
-#include <machine/Machine.h>
 #include <Log.h>
 
 #include <utilities/Tree.h>
-#include <utilities/MemoryTracing.h>
 
 Tree<void*, void*> g_FreedPointers;
 

--- a/src/system/kernel/core/lib/demangle.cc
+++ b/src/system/kernel/core/lib/demangle.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,7 +20,6 @@
 #include <utilities/utility.h>
 #include <utilities/demangle.h>
 #include <utilities/StaticString.h>
-#include <Log.h>
 
 // Uncomment these if running standalone.
 //include <stdio.h>

--- a/src/system/kernel/core/lib/dlmallocAbort.cc
+++ b/src/system/kernel/core/lib/dlmallocAbort.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,7 +18,6 @@
  */
 
 #include <panic.h>
-#include <processor/Processor.h>
 
 void dlmallocAbort()
 {

--- a/src/system/kernel/core/lib/dlmallocSbrk.cc
+++ b/src/system/kernel/core/lib/dlmallocSbrk.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -18,9 +17,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <processor/Processor.h>
 #include <Log.h>
-#include <processor/PhysicalMemoryManager.h>
 
 #if defined(TRACK_PAGE_ALLOCATIONS)
   #include <commands/AllocationCommand.h>

--- a/src/system/kernel/core/lib/instrument.cc
+++ b/src/system/kernel/core/lib/instrument.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -18,8 +17,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <machine/Machine.h>
-#include <utilities/StaticString.h>
+#include <processor/types.h>
 
 extern "C" void __cyg_profile_func_enter (void *func_address, void *call_site)
   __attribute__((no_instrument_function));

--- a/src/system/kernel/core/lib/memory.c
+++ b/src/system/kernel/core/lib/memory.c
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -18,11 +17,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <utilities/utility.h>
-#include <utilities/assert.h>
 #include <compiler.h>
-
-#include <panic.h>
+#include <processor/types.h>
 
 /**
     x86 note:

--- a/src/system/kernel/core/lib/random.c
+++ b/src/system/kernel/core/lib/random.c
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -18,7 +17,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <utilities/utility.h>
+#include <processor/types.h>
 
 static uint64_t g_Seed = 1;
 

--- a/src/system/kernel/core/main.cc
+++ b/src/system/kernel/core/main.cc
@@ -88,7 +88,6 @@
 
 #ifdef DEBUGGER
     #include <Debugger.h>
-    #include <LocksCommand.h>
 #endif
 
 #include <linker/KernelElf.h>             // KernelElf::initialise()
@@ -100,29 +99,19 @@
 #include "cppsupport.h"                   // initialiseConstructors()
 
 #include <processor/Processor.h>          // Processor::initialise1(), Processor::initialise2()
-#include <processor/PhysicalMemoryManager.h>
 #include <processor/KernelCoreSyscallManager.h>
 
 #include <machine/Machine.h>              // Machine::initialise()
-#include <LocalIO.h>
-#include <SerialIO.h>
-#include <DebuggerIO.h>
 #include "BootIO.h"
 
-#include <process/initialiseMultitasking.h>
 #include <process/Thread.h>
 #include <process/Scheduler.h>
-#include <process/SchedulingAlgorithm.h>
 #include <process/MemoryPressureManager.h>
-
-#include <machine/Device.h>
 
 #ifdef OPENFIRMWARE
     #include <machine/openfirmware/Device.h>
 #endif
 
-#include <utilities/List.h>
-#include <utilities/RadixTree.h>
 #include <utilities/StaticString.h>
 
 #include <utilities/Cache.h>
@@ -133,11 +122,10 @@
 #include <utilities/ZombieQueue.h>
 #endif
 
-#include <Module.h>
-
 #include <graphics/GraphicsService.h>
 
 #include <SlamAllocator.h>
+#include <ServiceManager.h>
 
 void apmm()
 {

--- a/src/system/kernel/core/process/Ipc.cc
+++ b/src/system/kernel/core/process/Ipc.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,12 +21,12 @@
 
 #include <utilities/RadixTree.h>
 
-#include <process/Scheduler.h>
-
 #include <processor/PhysicalMemoryManager.h>
 #include <processor/VirtualAddressSpace.h>
 
 #include <utilities/MemoryPool.h>
+
+#include <LockGuard.h>
 
 using namespace Ipc;
 

--- a/src/system/kernel/core/process/LockManager.cc
+++ b/src/system/kernel/core/process/LockManager.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,7 +18,6 @@
  */
 
 #include <process/LockManager.h>
-#include <processor/Processor.h>
 #include <Log.h>
 
 LockManager::LockManager() :

--- a/src/system/kernel/core/process/PerProcessorScheduler.cc
+++ b/src/system/kernel/core/process/PerProcessorScheduler.cc
@@ -21,6 +21,7 @@
 
 #include <process/PerProcessorScheduler.h>
 #include <process/Thread.h>
+#include <process/Process.h>
 #include <process/SchedulingAlgorithm.h>
 #include <process/RoundRobin.h>
 
@@ -31,11 +32,8 @@
 #include <machine/Machine.h>
 
 #include <Spinlock.h>
-#include <LockGuard.h>
 #include <panic.h>
 #include <Log.h>
-
-#include <utilities/assert.h>
 
 #ifdef TRACK_LOCKS
 #include <LocksCommand.h>

--- a/src/system/kernel/core/process/Process.cc
+++ b/src/system/kernel/core/process/Process.cc
@@ -24,16 +24,10 @@
 #include <processor/Processor.h>
 #include <process/Scheduler.h>
 #include <processor/VirtualAddressSpace.h>
-#include <linker/Elf.h>
-#include <processor/PhysicalMemoryManager.h>
 #include <Log.h>
 #include <utilities/ZombieQueue.h>
 
-#include <process/SignalEvent.h>
-
 #include <Subsystem.h>
-
-#include <vfs/File.h>
 
 Process::Process() :
   m_Threads(), m_NextTid(0), m_Id(0), str(), m_pParent(0), m_pAddressSpace(&VirtualAddressSpace::getKernelAddressSpace()),

--- a/src/system/kernel/core/process/ProcessorThreadAllocator.cc
+++ b/src/system/kernel/core/process/ProcessorThreadAllocator.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,8 +22,7 @@
 #include <process/PerProcessorScheduler.h>
 #include <process/Scheduler.h>
 #include <process/Thread.h>
-
-#include <processor/Processor.h>
+#include <process/ThreadToCoreAllocationAlgorithm.h>
 
 ProcessorThreadAllocator ProcessorThreadAllocator::m_Instance;
 

--- a/src/system/kernel/core/process/RoundRobin.cc
+++ b/src/system/kernel/core/process/RoundRobin.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,8 +20,6 @@
 #if defined(THREADS)
 #include <process/RoundRobin.h>
 #include <process/Thread.h>
-#include <processor/Processor.h>
-#include <Log.h>
 #include <LockGuard.h>
 #include <utilities/assert.h>
 

--- a/src/system/kernel/core/process/Scheduler.cc
+++ b/src/system/kernel/core/process/Scheduler.cc
@@ -20,16 +20,7 @@
 #if defined(THREADS)
 
 #include <process/Scheduler.h>
-#include <process/SchedulingAlgorithm.h>
-#include <process/Thread.h>
-#include <process/RoundRobin.h>
-#include <process/initialiseMultitasking.h>
 #include <processor/Processor.h>
-#include <processor/StackFrame.h>
-#include <processor/KernelCoreSyscallManager.h>
-#include <Debugger.h>
-#include <machine/Machine.h>
-#include <panic.h>
 #include <Log.h>
 #include <utilities/assert.h>
 #include <process/PerProcessorScheduler.h>

--- a/src/system/kernel/core/process/SignalEvent.cc
+++ b/src/system/kernel/core/process/SignalEvent.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -18,7 +17,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <Log.h>
 #include <processor/types.h>
 #include <process/Event.h>
 #include <process/SignalEvent.h>

--- a/src/system/kernel/core/process/Thread.cc
+++ b/src/system/kernel/core/process/Thread.cc
@@ -20,12 +20,11 @@
 #ifdef THREADS
 
 #include <process/Thread.h>
+#include <process/Process.h>
 #include <process/Scheduler.h>
 #include <process/SchedulingAlgorithm.h>
 #include <process/ProcessorThreadAllocator.h>
 #include <processor/Processor.h>
-#include <processor/StackFrame.h>
-#include <machine/Machine.h>
 #include <Log.h>
 
 #include <machine/InputManager.h>
@@ -265,6 +264,47 @@ void Thread::shutdown()
     m_Status = AwaitingJoin;
   }
   m_ConcurrencyLock.release();
+}
+
+SchedulerState &Thread::pushState()
+{
+    if ((m_nStateLevel + 1) >= MAX_NESTED_EVENTS)
+    {
+        ERROR("Thread: Max nested events!");
+        /// \todo Take some action here - possibly kill the thread?
+        return m_StateLevels[MAX_NESTED_EVENTS - 1].m_State;
+    }
+    m_nStateLevel++;
+    // NOTICE("New state level: " << m_nStateLevel << "...");
+    m_StateLevels[m_nStateLevel].m_InhibitMask = m_StateLevels[m_nStateLevel - 1].m_InhibitMask;
+    allocateStackAtLevel(m_nStateLevel);
+
+    setKernelStack();
+
+    return m_StateLevels[m_nStateLevel - 1].m_State;
+}
+
+void Thread::popState()
+{
+    if (m_nStateLevel == 0)
+    {
+        ERROR("Thread: Potential error: popStack() called with state level 0!");
+        ERROR("Thread: (ignore this if longjmp has been called)");
+        return;
+    }
+    m_nStateLevel --;
+
+    setKernelStack();
+}
+
+void Thread::pokeState(size_t stateLevel, SchedulerState &state)
+{
+    if (stateLevel >= MAX_NESTED_EVENTS)
+    {
+        ERROR("Thread::pokeState(): stateLevel `" << stateLevel << "' is over the maximum.");
+        return;
+    }
+    m_StateLevels[stateLevel].m_State = state;
 }
 
 void Thread::setStatus(Thread::Status s)

--- a/src/system/kernel/core/process/initialiseMultitasking.cc
+++ b/src/system/kernel/core/process/initialiseMultitasking.cc
@@ -19,15 +19,11 @@
 
 #if defined(THREADS)
 
-#include <Log.h>
-#include <process/initialiseMultitasking.h>
 #include <process/Thread.h>
 #include <process/Scheduler.h>
 #include <process/Process.h>
 #include <processor/Processor.h>
 #include <process/PerProcessorScheduler.h>
-#include <process/RoundRobinCoreAllocator.h>
-#include <process/ProcessorThreadAllocator.h>
 
 void initialiseMultitasking()
 {

--- a/src/system/kernel/core/processor/IoPort.cc
+++ b/src/system/kernel/core/processor/IoPort.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,7 +19,6 @@
 
 #include <processor/IoPort.h>
 #include <processor/IoPortManager.h>
-#include <panic.h>
 
 #if !defined(KERNEL_PROCESSOR_NO_PORT_IO)
 

--- a/src/system/kernel/core/processor/IoPortManager.cc
+++ b/src/system/kernel/core/processor/IoPortManager.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,7 +20,6 @@
 #include <LockGuard.h>
 #include <processor/Processor.h>
 #include <processor/IoPortManager.h>
-#include <panic.h>
 
 #if !defined(KERNEL_PROCESSOR_NO_PORT_IO)
 

--- a/src/system/kernel/core/processor/PageFaultHandler.cc
+++ b/src/system/kernel/core/processor/PageFaultHandler.cc
@@ -17,44 +17,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "Group.h"
+#include <processor/PageFaultHandler.h>
 
-Group::Group(size_t gid, String name) :
-  m_Gid(gid), m_Name(name), m_Users()
+void PageFaultHandler::registerHandler(MemoryTrapHandler *pHandler)
 {
-}
-
-Group::~Group()
-{
-}
-
-void Group::join(User *pUser)
-{
-  m_Users.pushBack(pUser);
-}
-
-void Group::leave(User *pUser)
-{
-  for (List<User*>::Iterator it = m_Users.begin();
-       it != m_Users.end();
-       it++)
-  {
-    if (*it == pUser)
-    {
-      m_Users.erase(it);
-      return;
-    }
-  }
-}
-
-bool Group::isMember(User *pUser)
-{
-  for (List<User*>::Iterator it = m_Users.begin();
-       it != m_Users.end();
-       it++)
-  {
-    if (*it == pUser)
-      return true;
-  }
-  return false;
+    m_Handlers.pushBack(pHandler);
 }

--- a/src/system/kernel/core/processor/PhysicalMemoryManager.cc
+++ b/src/system/kernel/core/processor/PhysicalMemoryManager.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,7 +19,6 @@
 
 #include <processor/PhysicalMemoryManager.h>
 #include <processor/MemoryRegion.h>
-#include <Log.h>
 
 void PhysicalMemoryManager::allocateMemoryRegionList(Vector<MemoryRegionInfo*> &MemoryRegions)
 {

--- a/src/system/kernel/core/processor/StackFrameBase.cc
+++ b/src/system/kernel/core/processor/StackFrameBase.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,8 +19,6 @@
 
 #if defined(DEBUGGER)
 
-#include <Log.h>
-#include <utilities/utility.h>
 #include <processor/StackFrameBase.h>
 
 StackFrameBase::StackFrameBase(const ProcessorState &State, uintptr_t basePointer,

--- a/src/system/kernel/core/processor/VirtualAddressSpace.cc
+++ b/src/system/kernel/core/processor/VirtualAddressSpace.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,7 +20,6 @@
 #include <utilities/utility.h>
 #include <processor/VirtualAddressSpace.h>
 #include <processor/PhysicalMemoryManager.h>
-#include <processor/Processor.h>
 #include <Log.h>
 
 void *VirtualAddressSpace::expandHeap(ssize_t incr, size_t flags)

--- a/src/system/kernel/core/processor/x64/InterruptManager.cc
+++ b/src/system/kernel/core/processor/x64/InterruptManager.cc
@@ -17,7 +17,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <panic.h>
 #include <LockGuard.h>
 #include <utilities/StaticString.h>
 #include "InterruptManager.h"

--- a/src/system/kernel/core/processor/x64/NMFaultHandler.cc
+++ b/src/system/kernel/core/processor/x64/NMFaultHandler.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,10 +18,7 @@
  */
 
 #include <Log.h>
-#include <Debugger.h>
 #include <processor/NMFaultHandler.h>
-#include <process/Scheduler.h>
-#include <processor/PhysicalMemoryManager.h>
 #include <processor/Processor.h>
 
 NMFaultHandler NMFaultHandler::m_Instance;

--- a/src/system/kernel/core/processor/x64/PageFaultHandler.cc
+++ b/src/system/kernel/core/processor/x64/PageFaultHandler.cc
@@ -21,6 +21,7 @@
 #include <Debugger.h>
 #include <processor/PageFaultHandler.h>
 #include <process/Scheduler.h>
+#include <process/Process.h>
 #include <panic.h>
 #include <processor/PhysicalMemoryManager.h>
 #include "VirtualAddressSpace.h"

--- a/src/system/kernel/core/processor/x64/SyscallManager.cc
+++ b/src/system/kernel/core/processor/x64/SyscallManager.cc
@@ -20,6 +20,8 @@
 #include <compiler.h>
 #include <LockGuard.h>
 #include <processor/Processor.h>
+#include <process/Process.h>
+
 #include "SyscallManager.h"
 
 X64SyscallManager X64SyscallManager::m_Instance;

--- a/src/system/kernel/core/processor/x64/state.cc
+++ b/src/system/kernel/core/processor/x64/state.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,6 +18,7 @@
  */
 
 #include <processor/state.h>
+#include <Log.h>
 
 const char *X64InterruptStateRegisterName[18] =
 {
@@ -153,4 +153,19 @@ X64InterruptState *X64InterruptState::construct(X64ProcessorState &state, bool u
   X64InterruptState *toRet = reinterpret_cast<X64InterruptState*> (pStack);
 
   return toRet;
+}
+
+uintptr_t X64SyscallState::getSyscallParameter(size_t n) const
+{
+  switch (n)
+  {
+    case 0: return m_Rbx;
+    case 1: return m_Rdx;
+    case 2: return m_Rsi;
+    case 3: return m_Rdi;
+    case 4: return m_R8;
+    default:
+      WARNING("Bad syscall parameter requested: " << Dec << n);
+      return 0;
+  }
 }

--- a/src/system/kernel/core/processor/x64/state.cc
+++ b/src/system/kernel/core/processor/x64/state.cc
@@ -18,6 +18,7 @@
  */
 
 #include <processor/state.h>
+#include <processor/types.h>
 #include <Log.h>
 
 const char *X64InterruptStateRegisterName[18] =

--- a/src/system/kernel/core/processor/x86_common/Disassembler.cc
+++ b/src/system/kernel/core/processor/x86_common/Disassembler.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,6 +18,7 @@
  */
 
 #include "Disassembler.h"
+#include <udis86.h>
 
 X86Disassembler::X86Disassembler()
   : m_Location(0), m_Mode(32), m_Obj()

--- a/src/system/kernel/core/processor/x86_common/Disassembler.h
+++ b/src/system/kernel/core/processor/x86_common/Disassembler.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,7 +21,9 @@
 #define MIPS_DISASSEMBLER_H
 
 #include <processor/Disassembler.h>
-#include <udis86.h>
+#include <processor/types.h>
+#include <utilities/StaticString.h>
+#include "types.h"
 
 /**
  * A disassembler for R3000-R6000 MIPS32/64 processors.

--- a/src/system/kernel/core/processor/x86_common/PhysicalMemoryManager.cc
+++ b/src/system/kernel/core/processor/x86_common/PhysicalMemoryManager.cc
@@ -17,21 +17,19 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <BootstrapInfo.h>
 #include <Log.h>
 #include <panic.h>
-#include <utilities/assert.h>
 #include <utilities/utility.h>
 #include <processor/MemoryRegion.h>
 #include <processor/Processor.h>
 #include "PhysicalMemoryManager.h"
 #include <LockGuard.h>
-#include <utilities/Cache.h>
 
 #if defined(X86)
 #include "../x86/VirtualAddressSpace.h"
 #elif defined(X64)
 #include "../x64/VirtualAddressSpace.h"
-#include "../x64/utils.h"
 #endif
 
 #if defined(X86) && defined(DEBUGGER)
@@ -46,7 +44,6 @@ uint32_t g_PageBitmap[16384] = {0};
 #include <commands/AllocationCommand.h>
 #endif
 
-#include <SlamAllocator.h>
 #include <process/MemoryPressureManager.h>
 
 X86CommonPhysicalMemoryManager X86CommonPhysicalMemoryManager::m_Instance;

--- a/src/system/kernel/core/processor/x86_common/PhysicalMemoryManager.h
+++ b/src/system/kernel/core/processor/x86_common/PhysicalMemoryManager.h
@@ -21,7 +21,6 @@
 #define KERNEL_PROCESSOR_X86_COMMON_PHYSICALMEMORYMANAGER_H
 
 #include <compiler.h>
-#include <BootstrapInfo.h>
 #include <utilities/RangeList.h>
 #include <utilities/HashTable.h>
 #include <processor/PhysicalMemoryManager.h>

--- a/src/system/kernel/core/processor/x86_common/Processor.cc
+++ b/src/system/kernel/core/processor/x86_common/Processor.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,11 +19,6 @@
 
 #include <processor/Processor.h>
 #include "PhysicalMemoryManager.h"
-#if defined(X86)
-  #include "../../core/processor/x86/VirtualAddressSpace.h"
-#else
-  #include "../../core/processor/x64/VirtualAddressSpace.h"
-#endif
 
 void Processor::initialisationDone()
 {

--- a/src/system/kernel/debugger/Backtrace.cc
+++ b/src/system/kernel/debugger/Backtrace.cc
@@ -18,10 +18,10 @@
  */
 
 #include <Backtrace.h>
-#include <utilities/utility.h>
 #include <Log.h>
 #include <DwarfUnwinder.h>
 #include <linker/KernelElf.h>
+#include <processor/StackFrame.h>
 
 extern uintptr_t start;
 

--- a/src/system/kernel/debugger/Backtrace.h
+++ b/src/system/kernel/debugger/Backtrace.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,8 +20,7 @@
 #ifndef BACKTRACE_H
 #define BACKTRACE_H
 
-#include <processor/Processor.h>
-#include <processor/StackFrame.h>
+#include <processor/state.h>
 #include <utilities/StaticString.h>
 
 /** @addtogroup kerneldebugger

--- a/src/system/kernel/debugger/Debugger.cc
+++ b/src/system/kernel/debugger/Debugger.cc
@@ -39,17 +39,16 @@
 #include <IoCommand.h>
 #include <ThreadsCommand.h>
 #include <DevicesCommand.h>
-#include <LookupCommand.h>
 #include <SyscallTracerCommand.h>
 #include <LookupCommand.h>
 #include <HelpCommand.h>
 #include <LocksCommand.h>
 #include <MappingCommand.h>
-#include <process/Thread.h>
-#include <process/initialiseMultitasking.h>
 #include <machine/Machine.h>
-#include <process/Scheduler.h>
 #include <graphics/GraphicsService.h>
+#include <processor/InterruptManager.h>
+#include <ServiceManager.h>
+#include <machine/Display.h>
 
 Debugger Debugger::m_Instance;
 

--- a/src/system/kernel/debugger/Debugger.h
+++ b/src/system/kernel/debugger/Debugger.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,10 +20,10 @@
 #ifndef DEBUGGER_H
 #define DEBUGGER_H
 
-#include <processor/Processor.h>
 #include <processor/state.h>
-#include <processor/InterruptManager.h>
-#include <LocalIO.h>
+#include <processor/InterruptHandler.h>
+#include <processor/types.h>
+#include <utilities/StaticString.h>
 
 /** @addtogroup kerneldebugger
  * @{ */

--- a/src/system/kernel/debugger/DwarfUnwinder.h
+++ b/src/system/kernel/debugger/DwarfUnwinder.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -24,7 +23,6 @@
 /** @addtogroup kerneldebugger
  * @{ */
 
-#include <compiler.h>
 #include <processor/state.h>
 #include <processor/types.h>
 

--- a/src/system/kernel/debugger/LocalIO.cc
+++ b/src/system/kernel/debugger/LocalIO.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,10 +18,9 @@
  */
 
 #include <LocalIO.h>
-#include <Log.h>
-#include <DebuggerCommand.h>
-#include <utilities/utility.h>
-#include <machine/Machine.h>
+
+#include <machine/Keyboard.h>
+#include <machine/Vga.h>
 
 LocalIO::LocalIO(Vga *pVga, Keyboard *pKeyboard) :
   m_nWidth(80),

--- a/src/system/kernel/debugger/LocalIO.h
+++ b/src/system/kernel/debugger/LocalIO.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -25,10 +24,9 @@
  * @{ */
 
 #include <DebuggerIO.h>
-#include <machine/Vga.h>
-#include <machine/Keyboard.h>
 
-class DebuggerCommand;
+class Keyboard;
+class Vga;
 
 #ifdef PPC_COMMON
 #define MAX_CONSOLE_WIDTH 128

--- a/src/system/kernel/debugger/Scrollable.cc
+++ b/src/system/kernel/debugger/Scrollable.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,7 +18,6 @@
  */
 
 #include "Scrollable.h"
-#include <Log.h>
 
 void Scrollable::move(size_t x, size_t y)
 {

--- a/src/system/kernel/debugger/SerialIO.cc
+++ b/src/system/kernel/debugger/SerialIO.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,13 +18,11 @@
  */
 
 #include <SerialIO.h>
-#include <DebuggerCommand.h>
 #include <utilities/utility.h>
-#include <processor/IoPort.h>
 #include <Log.h>
 #include <utilities/StaticString.h>
-/// \todo needs a bit of a tidyup!
-#include <processor/Processor.h>
+
+#include <machine/Serial.h>
 
 SerialIO::SerialIO(Serial *pSerial) :
   m_UpperCliLimit(0),

--- a/src/system/kernel/debugger/SerialIO.h
+++ b/src/system/kernel/debugger/SerialIO.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,7 +21,8 @@
 #define SERIALIO_H
 
 #include <DebuggerIO.h>
-#include <machine/Serial.h>
+
+class Serial;
 
 /** @addtogroup kerneldebugger
  * @{ */

--- a/src/system/kernel/debugger/SyscallTracer.h
+++ b/src/system/kernel/debugger/SyscallTracer.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -17,8 +16,6 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-
-#include <processor/Processor.h>
 
 class SyscallTracer
 {

--- a/src/system/kernel/debugger/assert.cc
+++ b/src/system/kernel/debugger/assert.cc
@@ -17,23 +17,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <Debugger.h>
-
-#include <DebuggerIO.h>
-#include <LocalIO.h>
-#include <SerialIO.h>
-
-#include <utilities/StaticString.h>
-
 #include <processor/Processor.h>
-#include <machine/Machine.h>
 
 #include <Log.h>
-#include <utilities/utility.h>
 
 #include <panic.h>
-
-#include <utilities/assert.h>
 
 void _assert(bool b, const char *file, int line, const char *func)
 {

--- a/src/system/kernel/debugger/commands/AllocationCommand.cc
+++ b/src/system/kernel/debugger/commands/AllocationCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,7 +21,6 @@
 #include <Log.h>
 #include <utilities/utility.h>
 #include <DebuggerIO.h>
-#include <process/Scheduler.h>
 #include <process/Process.h>
 #include <linker/KernelElf.h>
 #include <utilities/demangle.h>

--- a/src/system/kernel/debugger/commands/Backtracer.cc
+++ b/src/system/kernel/debugger/commands/Backtracer.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,11 +19,7 @@
 
 #include <Backtracer.h>
 #include <Backtrace.h>
-#include <DebuggerIO.h>
-#include <utilities/utility.h>
 #include <utilities/StaticString.h>
-
-#include <DwarfUnwinder.h>
 
 Backtracer::Backtracer()
 {

--- a/src/system/kernel/debugger/commands/BreakpointCommand.cc
+++ b/src/system/kernel/debugger/commands/BreakpointCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,10 +18,9 @@
  */
 
 #include "BreakpointCommand.h"
-#include <Log.h>
-#include <utilities/utility.h>
-#include <DebuggerIO.h>
 #include <processor/Processor.h>
+
+class DebuggerIO;
 
 BreakpointCommand::BreakpointCommand()
  : DebuggerCommand()

--- a/src/system/kernel/debugger/commands/CpuInfoCommand.cc
+++ b/src/system/kernel/debugger/commands/CpuInfoCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,10 +18,6 @@
  */
 
 #include <CpuInfoCommand.h>
-#include <DebuggerIO.h>
-#include <udis86.h>
-#include <Log.h>
-#include <utilities/demangle.h>
 #include <processor/Processor.h>
 
 

--- a/src/system/kernel/debugger/commands/DevicesCommand.cc
+++ b/src/system/kernel/debugger/commands/DevicesCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,12 +18,9 @@
  */
 
 #include "DevicesCommand.h"
-#include <utilities/utility.h>
 #include <DebuggerIO.h>
-#include <processor/Processor.h>
-#include <Log.h>
-#include <machine/Machine.h>
-#include <linker/KernelElf.h>
+#include <machine/Device.h>
+#include <utilities/String.h>
 
 DevicesCommand::DevicesCommand()
   : DebuggerCommand()

--- a/src/system/kernel/debugger/commands/DevicesCommand.h
+++ b/src/system/kernel/debugger/commands/DevicesCommand.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,8 +22,9 @@
 
 #include <DebuggerCommand.h>
 #include <Scrollable.h>
-#include <machine/Device.h>
 #include <utilities/Vector.h>
+
+class Device;
 
 /** @addtogroup kerneldebuggercommands
  * @{ */

--- a/src/system/kernel/debugger/commands/DisassembleCommand.cc
+++ b/src/system/kernel/debugger/commands/DisassembleCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,12 +18,9 @@
  */
 
 #include <DisassembleCommand.h>
-#include <DebuggerIO.h>
-#include <udis86.h>
-#include <Log.h>
 #include <utilities/demangle.h>
-#include <processor/Disassembler.h>
 #include <linker/KernelElf.h>
+#include <processor/Disassembler.h>
 
 DisassembleCommand::DisassembleCommand()
 {

--- a/src/system/kernel/debugger/commands/DumpCommand.cc
+++ b/src/system/kernel/debugger/commands/DumpCommand.cc
@@ -19,7 +19,6 @@
 
 #include "DumpCommand.h"
 #include <utilities/utility.h>
-#include <processor/Processor.h>
 
 DumpCommand::DumpCommand()
  : DebuggerCommand()

--- a/src/system/kernel/debugger/commands/HelpCommand.cc
+++ b/src/system/kernel/debugger/commands/HelpCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,8 +18,6 @@
  */
 
 #include "HelpCommand.h"
-#include <utilities/utility.h>
-#include <processor/Processor.h>
 
 HelpCommand::HelpCommand()
  : DebuggerCommand()

--- a/src/system/kernel/debugger/commands/IoCommand.cc
+++ b/src/system/kernel/debugger/commands/IoCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,7 +18,6 @@
  */
 
 #include "IoCommand.h"
-#include <DebuggerIO.h>
 #include <processor/IoPortManager.h>
 #include <processor/PhysicalMemoryManager.h>
 

--- a/src/system/kernel/debugger/commands/LocksCommand.cc
+++ b/src/system/kernel/debugger/commands/LocksCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,11 +19,10 @@
 
 #include "LocksCommand.h"
 #include <utilities/utility.h>
-#include <processor/Processor.h>
 #include <linker/KernelElf.h>
 #include <utilities/demangle.h>
-#include <processor/Processor.h>
 #include <Backtrace.h>
+#include <Spinlock.h>
 
 LocksCommand g_LocksCommand;
 extern Spinlock g_MallocLock;

--- a/src/system/kernel/debugger/commands/LocksCommand.h
+++ b/src/system/kernel/debugger/commands/LocksCommand.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,7 +21,8 @@
 #define LOCKSCOMMAND_H
 
 #include <DebuggerCommand.h>
-#include <Spinlock.h>
+
+class Spinlock;
 
 /** @addtogroup kerneldebuggercommands
  * @{ */

--- a/src/system/kernel/debugger/commands/LogViewer.cc
+++ b/src/system/kernel/debugger/commands/LogViewer.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,7 +19,6 @@
 
 #include "LogViewer.h"
 #include <Log.h>
-#include <utilities/utility.h>
 #include <DebuggerIO.h>
 
 LogViewer::LogViewer()

--- a/src/system/kernel/debugger/commands/LookupCommand.cc
+++ b/src/system/kernel/debugger/commands/LookupCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,8 +18,6 @@
  */
 
 #include "LookupCommand.h"
-#include <utilities/utility.h>
-#include <processor/Processor.h>
 #include <linker/KernelElf.h>
 
 LookupCommand::LookupCommand()

--- a/src/system/kernel/debugger/commands/MappingCommand.cc
+++ b/src/system/kernel/debugger/commands/MappingCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,7 +18,6 @@
  */
 
 #include "MappingCommand.h"
-#include <utilities/utility.h>
 #include <processor/Processor.h>
 #include <processor/VirtualAddressSpace.h>
 #include <processor/PhysicalMemoryManager.h>

--- a/src/system/kernel/debugger/commands/MappingCommand.h
+++ b/src/system/kernel/debugger/commands/MappingCommand.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -22,7 +21,6 @@
 #define MAPPINGCOMMAND_H
 
 #include <DebuggerCommand.h>
-#include <Spinlock.h>
 
 /** @addtogroup kerneldebuggercommands
  * @{ */

--- a/src/system/kernel/debugger/commands/PanicCommand.cc
+++ b/src/system/kernel/debugger/commands/PanicCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,10 +18,9 @@
  */
 
 #include "PanicCommand.h"
-#include <Log.h>
-#include <utilities/utility.h>
-#include <DebuggerIO.h>
 #include <panic.h>
+
+class DebuggerIO;
 
 PanicCommand::PanicCommand()
  : DebuggerCommand()

--- a/src/system/kernel/debugger/commands/QuitCommand.cc
+++ b/src/system/kernel/debugger/commands/QuitCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,9 +18,6 @@
  */
 
 #include "QuitCommand.h"
-#include <Log.h>
-#include <utilities/utility.h>
-#include <DebuggerIO.h>
 
 QuitCommand::QuitCommand()
  : DebuggerCommand()

--- a/src/system/kernel/debugger/commands/SlamCommand.cc
+++ b/src/system/kernel/debugger/commands/SlamCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,14 +18,10 @@
  */
 
 #include "SlamCommand.h"
-#include <Log.h>
 #include <utilities/utility.h>
 #include <DebuggerIO.h>
-#include <process/Scheduler.h>
-#include <process/Process.h>
 #include <linker/KernelElf.h>
 #include <utilities/demangle.h>
-#include <processor/Processor.h>
 #include <machine/Machine.h>
 
 SlamCommand g_SlamCommand;

--- a/src/system/kernel/debugger/commands/SlamCommand.h
+++ b/src/system/kernel/debugger/commands/SlamCommand.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,7 +22,6 @@
 
 #include <DebuggerCommand.h>
 #include <Scrollable.h>
-#include <utilities/Vector.h>
 #include <utilities/Tree.h>
 
 /** @addtogroup kerneldebuggercommands

--- a/src/system/kernel/debugger/commands/StepCommand.cc
+++ b/src/system/kernel/debugger/commands/StepCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,9 +18,6 @@
  */
 
 #include "StepCommand.h"
-#include <Log.h>
-#include <utilities/utility.h>
-#include <DebuggerIO.h>
 #include <processor/Processor.h>
 
 StepCommand::StepCommand()

--- a/src/system/kernel/debugger/commands/SyscallTracerCommand.h
+++ b/src/system/kernel/debugger/commands/SyscallTracerCommand.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -18,10 +17,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <processor/Processor.h>
 #include <DebuggerCommand.h>
 #include <Scrollable.h>
-#include <Log.h>
 
 class SyscallTracerCommand :  public DebuggerCommand,
                               public Scrollable

--- a/src/system/kernel/debugger/commands/ThreadsCommand.cc
+++ b/src/system/kernel/debugger/commands/ThreadsCommand.cc
@@ -20,14 +20,11 @@
 #if defined(THREADS)
 
 #include "ThreadsCommand.h"
-#include <Log.h>
-#include <utilities/utility.h>
 #include <DebuggerIO.h>
 #include <process/Scheduler.h>
 #include <process/Process.h>
 #include <linker/KernelElf.h>
 #include <utilities/demangle.h>
-#include <process/initialiseMultitasking.h>
 #include <processor/Processor.h>
 
 ThreadsCommand::ThreadsCommand()

--- a/src/system/kernel/debugger/commands/ThreadsCommand.h
+++ b/src/system/kernel/debugger/commands/ThreadsCommand.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -25,7 +24,8 @@
 
 #include <DebuggerCommand.h>
 #include <Scrollable.h>
-#include <process/Thread.h>
+
+class Thread;
 
 /** @addtogroup kerneldebuggercommands
  * @{ */

--- a/src/system/kernel/debugger/commands/TraceCommand.cc
+++ b/src/system/kernel/debugger/commands/TraceCommand.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,15 +18,11 @@
  */
 
 #include "TraceCommand.h"
-#include <utilities/utility.h>
 #include <DebuggerIO.h>
 #include <processor/Processor.h>
-#include <udis86.h>
-#include <Log.h>
 #include <utilities/demangle.h>
-#include <machine/Machine.h>
-#include <processor/Disassembler.h>
 #include <linker/KernelElf.h>
+#include <processor/Disassembler.h>
 
 TraceCommand::TraceCommand()
   : DebuggerCommand(),

--- a/src/system/kernel/debugger/panic.cc
+++ b/src/system/kernel/debugger/panic.cc
@@ -17,8 +17,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <Debugger.h>
-
 #include <DebuggerIO.h>
 #include <LocalIO.h>
 #include <SerialIO.h>
@@ -27,10 +25,12 @@
 
 #include <processor/Processor.h>
 #include <machine/Machine.h>
+#include <machine/Display.h>
 
 #include <Log.h>
 #include <utilities/utility.h>
 
+#include <ServiceManager.h>
 #include <graphics/GraphicsService.h>
 
 static size_t newlineCount(const char *pString)

--- a/src/system/kernel/graphics/GraphicsService.cc
+++ b/src/system/kernel/graphics/GraphicsService.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,6 +19,10 @@
 
 #include <graphics/GraphicsService.h>
 #include <processor/types.h>
+#include <machine/Display.h>
+#include <utilities/utility.h>
+#include <utilities/String.h>
+#include <Log.h>
 
 bool GraphicsService::serve(ServiceFeatures::Type type, void *pData, size_t dataLen)
 {

--- a/src/system/kernel/linker/Elf.cc
+++ b/src/system/kernel/linker/Elf.cc
@@ -20,7 +20,6 @@
 #include <Log.h>
 #include <linker/Elf.h>
 #include <utilities/utility.h>
-#include <BootstrapInfo.h>
 #include <processor/Processor.h>
 #include <processor/PhysicalMemoryManager.h>
 #include <linker/KernelElf.h>

--- a/src/system/kernel/linker/KernelElf.cc
+++ b/src/system/kernel/linker/KernelElf.cc
@@ -17,12 +17,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <BootstrapInfo.h>
 #include <linker/KernelElf.h>
 #include <utilities/utility.h>
 #include <processor/Processor.h>
 #include <processor/VirtualAddressSpace.h>
 #include <processor/PhysicalMemoryManager.h>
-#include <utilities/MemoryTracing.h>
 #include <Log.h>
 
 KernelElf KernelElf::m_Instance;

--- a/src/system/kernel/linker/SymbolTable.cc
+++ b/src/system/kernel/linker/SymbolTable.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,7 +18,6 @@
  */
 
 #include <linker/SymbolTable.h>
-#include <linker/Elf.h>
 
 SymbolTable::SymbolTable(Elf *pElf) :
   m_Tree(), m_pOriginatingElf(pElf)

--- a/src/system/kernel/machine/Framebuffer.cc
+++ b/src/system/kernel/machine/Framebuffer.cc
@@ -21,10 +21,6 @@
 #include <processor/MemoryRegion.h>
 #include <processor/PhysicalMemoryManager.h>
 #include <processor/VirtualAddressSpace.h>
-#include <processor/Processor.h>
-#include <machine/Display.h>
-
-#include <Log.h>
 
 Graphics::Buffer *Framebuffer::swCreateBuffer(const void *srcData, Graphics::PixelFormat srcFormat, size_t width, size_t height, uint32_t *pPalette)
 {

--- a/src/system/kernel/machine/HidInputManager.cc
+++ b/src/system/kernel/machine/HidInputManager.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -24,7 +23,6 @@
 #include <machine/Machine.h>
 #include <machine/Timer.h>
 #include <LockGuard.h>
-#include <Log.h>
 
 HidInputManager HidInputManager::m_Instance;
 

--- a/src/system/kernel/machine/KeymapManager.cc
+++ b/src/system/kernel/machine/KeymapManager.cc
@@ -20,9 +20,10 @@
 #include <machine/KeymapManager.h>
 #include <machine/HidInputManager.h>
 #include <machine/Keyboard.h>
-#include <Log.h>
 
 #include <machine/keymaps/KeymapEnUs.h>
+
+#include <Spinlock.h>
 
 // #define DEBUG_KEYMAP
 

--- a/src/system/kernel/machine/Network.cc
+++ b/src/system/kernel/machine/Network.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,10 +18,6 @@
  */
 
 #include <machine/Network.h>
-#include <processor/IoPort.h>
-#include <processor/MemoryMappedIo.h>
-#include <processor/PhysicalMemoryManager.h>
-#include <Log.h>
 
 uint32_t Network::convertToIpv4(uint8_t a, uint8_t b, uint8_t c, uint8_t d)
 {

--- a/src/system/kernel/machine/mach_pc/Bios.cc
+++ b/src/system/kernel/machine/mach_pc/Bios.cc
@@ -21,6 +21,7 @@
 #include <processor/Processor.h>
 #include <utilities/StaticString.h>
 #include <processor/VirtualAddressSpace.h>
+#include <Log.h>
 
 #include "../../core/BootIO.h"
 #include "x86emu/x86emu.h"

--- a/src/system/kernel/machine/mach_pc/Keyboard.cc
+++ b/src/system/kernel/machine/mach_pc/Keyboard.cc
@@ -20,6 +20,7 @@
 #include <machine/Machine.h>
 #include <machine/HidInputManager.h>
 #include <machine/KeymapManager.h>
+#include <processor/IoBase.h>
 #include <machine/Device.h>
 #include "Keyboard.h"
 

--- a/src/system/kernel/machine/mach_pc/Keyboard.h
+++ b/src/system/kernel/machine/mach_pc/Keyboard.h
@@ -21,10 +21,8 @@
 #define MACHINE_X86_KEYBOARD_H
 
 #include <machine/Keyboard.h>
-#include <machine/IrqManager.h>
 #include <machine/KeymapManager.h>
 #include <processor/types.h>
-#include <processor/IoPort.h>
 #include <process/Semaphore.h>
 
 #define BUFLEN 256

--- a/src/system/kernel/machine/mach_pc/Pc.cc
+++ b/src/system/kernel/machine/mach_pc/Pc.cc
@@ -31,9 +31,12 @@
 #endif
 #include <machine/Device.h>
 #include <machine/Bus.h>
-#include <machine/Disk.h>
 #include <machine/Controller.h>
 #include <machine/Pci.h>
+#include "Pic.h"
+#include "Rtc.h"
+#include "Pit.h"
+#include "Keyboard.h"
 
 Pc Pc::m_Instance;
 

--- a/src/system/kernel/machine/mach_pc/Pc.h
+++ b/src/system/kernel/machine/mach_pc/Pc.h
@@ -21,16 +21,18 @@
 #define KERNEL_MACHINE_X86_COMMON_PC_H
 
 #include <machine/Machine.h>
-#include "Pic.h"
-#include "Rtc.h"
-#include "Pit.h"
 #include "Serial.h"
 #include "Vga.h"
-#include "Keyboard.h"
 #if defined(SMBIOS)
   #include "SMBios.h"
 #endif
-#include "LocalApic.h"
+
+class IrqManager;
+class Keyboard;
+class SchedulerTimer;
+class Serial;
+class Timer;
+class Vga;
 
 /**
  * Concretion of the abstract Machine class for x86 and x64 machines

--- a/src/system/kernel/machine/mach_pc/Pci.cc
+++ b/src/system/kernel/machine/mach_pc/Pci.cc
@@ -19,9 +19,7 @@
 
 #include <Log.h>
 #include <processor/types.h>
-#include <machine/Machine.h>
 #include <machine/Device.h>
-#include <machine/Bus.h>
 #include <processor/IoPort.h>
 #include <utilities/utility.h>
 #include <machine/Pci.h>

--- a/src/system/kernel/machine/mach_pc/Pic.cc
+++ b/src/system/kernel/machine/mach_pc/Pic.cc
@@ -19,9 +19,9 @@
 
 #include <compiler.h>
 #include <Log.h>
-#include <Debugger.h>
 #include "Pic.h"
 #include <LockGuard.h>
+#include <processor/InterruptManager.h>
 
 // TODO: Needs locking
 

--- a/src/system/kernel/machine/mach_pc/Pic.h
+++ b/src/system/kernel/machine/mach_pc/Pic.h
@@ -21,7 +21,7 @@
 #define KERNEL_MACHINE_X86_COMMON_PIC_H
 
 #include <processor/IoPort.h>
-#include <processor/InterruptManager.h>
+#include <processor/InterruptHandler.h>
 #include <machine/IrqManager.h>
 #include <utilities/List.h>
 

--- a/src/system/kernel/machine/mach_pc/Pit.cc
+++ b/src/system/kernel/machine/mach_pc/Pit.cc
@@ -19,7 +19,6 @@
 
 #include <compiler.h>
 #include <machine/Machine.h>
-#include <Log.h>
 #include "Pit.h"
 
 /** Hundred hertz frequency. */

--- a/src/system/kernel/machine/mach_pc/Pit.h
+++ b/src/system/kernel/machine/mach_pc/Pit.h
@@ -21,7 +21,6 @@
 #define KERNEL_MACHINE_X86_COMMON_PIT_H
 
 #include <processor/IoPort.h>
-#include <machine/IrqManager.h>
 #include <machine/SchedulerTimer.h>
 #include <processor/state.h>
 

--- a/src/system/kernel/machine/mach_pc/Rtc.cc
+++ b/src/system/kernel/machine/mach_pc/Rtc.cc
@@ -19,7 +19,6 @@
 
 #include <compiler.h>
 #include <machine/Machine.h>
-#include <process/Event.h>
 #include <process/Thread.h>
 #include "Rtc.h"
 

--- a/src/system/kernel/machine/mach_pc/Rtc.h
+++ b/src/system/kernel/machine/mach_pc/Rtc.h
@@ -21,7 +21,6 @@
 #define KERNEL_MACHINE_X86_COMMON_RTC_H
 
 #include <processor/IoPort.h>
-#include <machine/IrqManager.h>
 #include <machine/Timer.h>
 #include <processor/state.h>
 

--- a/src/system/kernel/machine/mach_pc/Serial.h
+++ b/src/system/kernel/machine/mach_pc/Serial.h
@@ -20,7 +20,6 @@
 #ifndef MACHINE_X86_SERIAL_H
 #define MACHINE_X86_SERIAL_H
 
-#include <compiler.h>
 #include <processor/types.h>
 #include <processor/IoPort.h>
 #include <machine/Serial.h>

--- a/src/system/kernel/machine/mach_pc/Vga.cc
+++ b/src/system/kernel/machine/mach_pc/Vga.cc
@@ -23,9 +23,6 @@
 #include <processor/PhysicalMemoryManager.h>
 #include <machine/x86_common/Bios.h>
 
-#include <Log.h>
-#include <panic.h>
-
 X86Vga::X86Vga(uint32_t nRegisterBase, uint32_t nFramebufferBase) :
   m_RegisterPort("VGA controller"),
   m_Framebuffer("VGA framebuffer"),

--- a/src/system/kernel/network/IpAddress.cc
+++ b/src/system/kernel/network/IpAddress.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,6 +18,7 @@
  */
 
 #include <network/IpAddress.h>
+#include <utilities/StaticString.h>
 
 bool IpAddress::isLinkLocal()
 {

--- a/src/system/kernel/utilities/Cache.cc
+++ b/src/system/kernel/utilities/Cache.cc
@@ -21,7 +21,6 @@
 #include <processor/VirtualAddressSpace.h>
 #include <utilities/Cache.h>
 #include <utilities/assert.h>
-#include <utilities/utility.h>
 #include <machine/Timer.h>
 #include <machine/Machine.h>
 

--- a/src/system/kernel/utilities/ExtensibleBitmap.cc
+++ b/src/system/kernel/utilities/ExtensibleBitmap.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -20,7 +19,6 @@
 
 #include <utilities/ExtensibleBitmap.h>
 #include <utilities/utility.h>
-#include <Log.h>
 
 ExtensibleBitmap::ExtensibleBitmap() :
     m_StaticMap(0), m_pDynamicMap(0), m_DynamicMapSize(0), m_nMaxBit(0),

--- a/src/system/kernel/utilities/List.cc
+++ b/src/system/kernel/utilities/List.cc
@@ -19,7 +19,6 @@
 
 #include <utilities/List.h>
 #include <Log.h>
-#include <processor/Processor.h>
 
 //
 // List<void*> implementation

--- a/src/system/kernel/utilities/MemoryPool.cc
+++ b/src/system/kernel/utilities/MemoryPool.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -18,7 +17,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <processor/Processor.h>
 #include <utilities/MemoryPool.h>
 #include <processor/VirtualAddressSpace.h>
 #include <LockGuard.h>

--- a/src/system/kernel/utilities/RadixTree.cc
+++ b/src/system/kernel/utilities/RadixTree.cc
@@ -18,6 +18,7 @@
  */
 
 #include <utilities/RadixTree.h>
+#include <Log.h>
 
 //
 // RadixTree<void*> implementation.

--- a/src/system/kernel/utilities/RequestQueue.cc
+++ b/src/system/kernel/utilities/RequestQueue.cc
@@ -20,10 +20,9 @@
 #include <utilities/RequestQueue.h>
 #include <processor/Processor.h>
 #include <process/Scheduler.h>
-#include <panic.h>
 #include <Log.h>
 
-#include <utilities/assert.h>
+#include <LockGuard.h>
 
 RequestQueue::RequestQueue() :
   m_Stop(false), m_RequestQueueMutex(false)

--- a/src/system/kernel/utilities/String.cc
+++ b/src/system/kernel/utilities/String.cc
@@ -19,7 +19,6 @@
 
 #include <utilities/utility.h>
 #include <utilities/String.h>
-#include <Log.h>
 
 void String::assign(const String &x)
 {

--- a/src/system/kernel/utilities/TimeoutGuard.cc
+++ b/src/system/kernel/utilities/TimeoutGuard.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -21,7 +20,6 @@
 #include <utilities/TimeoutGuard.h>
 #ifdef THREADS
 #include <process/Thread.h>
-#include <process/PerProcessorScheduler.h>
 #endif
 #include <processor/Processor.h>
 #include <machine/Timer.h>

--- a/src/system/kernel/utilities/Tree.cc
+++ b/src/system/kernel/utilities/Tree.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -19,4 +18,3 @@
  */
 
 #include <utilities/Tree.h>
-#include <Log.h>


### PR DESCRIPTION
This uses explicit dependencies and forward declarations to reduce the size of the dependency tree, potentially resulting in faster builds.
