### PR TITLE
Replace ext2 builds using debugfs with a custom tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: cpp
+compiler: clang
 matrix:
   include:
   - os: linux
@@ -10,7 +11,7 @@ matrix:
     env: OS=ubuntu EASY_BUILD=hosted
   exclude:
     - os: linux
-    - compiler: gcc
+    - compiler: clang
 script:
   - ./easy_build_$EASY_BUILD.sh nosudo $OS
   - ./scripts/runtest.py
@@ -41,6 +42,7 @@ addons:
       - qemu
       - nasm
       - uboot-mkimage
+      - clang
 cache:
   directories:
   - $HOME/.ccache

--- a/SConscript
+++ b/SConscript
@@ -25,7 +25,11 @@ import SCons
 from buildutils import fs, db
 from buildutils.diskimages import build
 
-Import(['env', 'userspace_env'])
+Import(['env', 'userspace_env', 'host_env'])
+
+# Build utilities that run on the host during the kernel build.
+SConscript(os.path.join('src', 'buildutil', 'SConscript'), exports=['host_env'],
+           variant_dir=host_env['BUILDDIR'], duplicate=0)
 
 if env['build_modules']:
   # POSIX subsystem.

--- a/SConstruct
+++ b/SConstruct
@@ -223,7 +223,14 @@ Help(opts.GenerateHelpText(env))
 
 # Load the host environment now - this is a boring, standard environment that
 # doesn't need many flags from the main build.
-host_env = Environment(platform='posix')
+host_environ = {}
+host_cxx = os.environ.get('CXX')
+host_cc = os.environ.get('CC')
+if host_cxx:
+    host_environ['CXX'] = host_cxx
+if host_cc:
+    host_environ['CC'] = host_cc
+host_env = Environment(platform='posix', **host_environ)
 
 # Copy useful environment items that are needed in site_scons/buildutils
 for copy_key in ('verbose', 'nocolour'):

--- a/SConstruct
+++ b/SConstruct
@@ -208,6 +208,9 @@ environment = {
     # Needed to pass in preloads for Bear to build compilation databases.
     'LD_PRELOAD': os.environ.get('LD_PRELOAD', ''),
     'DYLD_INSERT_LIBRARIES': os.environ.get('DYLD_INSERT_LIBRARIES', ''),
+    # Pull in extra ccache configuration.
+    'CCACHE_DIR': os.environ.get('CCACHE_DIR', ''),
+    'CCACHE_TEMPDIR': os.environ.get('CCACHE_DIR', ''),
 }
 try:
     env = Environment(options=opts, platform='posix', ENV=environment,
@@ -217,6 +220,14 @@ except SCons.Errors.EnvironmentError:
     env = Environment(options=opts, platform='posix', ENV=environment,
                       tools=tools_to_find, TARFLAGS='-cz')
 Help(opts.GenerateHelpText(env))
+
+# Load the host environment now - this is a boring, standard environment that
+# doesn't need many flags from the main build.
+host_env = Environment(platform='posix')
+
+# Copy useful environment items that are needed in site_scons/buildutils
+for copy_key in ('verbose', 'nocolour'):
+    host_env[copy_key] = env[copy_key]
 
 def memoized_scons_subst(cache, old_scons_subst, string, env,
                          mode=SCons.Subst.SUBST_RAW, target=None, source=None,
@@ -365,12 +376,16 @@ env['PROGSUFFIX'] = ''
 
 # Determine build directories (these can be outside the source tree).
 env['BUILDDIR'] = env.Dir(env['BUILDDIR']).abspath  # Normalise path.
+env['HOST_BUILDDIR'] = os.path.join(env['BUILDDIR'], 'host')
 env['PEDIGREE_BUILD_BASE'] = env['BUILDDIR']
 env['PEDIGREE_BUILD_MODULES'] = os.path.join(env['BUILDDIR'], 'modules')
 env['PEDIGREE_BUILD_KERNEL'] = os.path.join(env['BUILDDIR'], 'kernel')
 env['PEDIGREE_BUILD_DRIVERS'] = os.path.join(env['BUILDDIR'], 'drivers')
 env['PEDIGREE_BUILD_SUBSYS'] = os.path.join(env['BUILDDIR'], 'subsystems')
 env['PEDIGREE_BUILD_APPS'] = os.path.join(env['BUILDDIR'], 'apps')
+
+# Add host build output path.
+host_env['BUILDDIR'] = env['HOST_BUILDDIR']
 
 # Set up compilers and in particular the cross-compile environment.
 if env['CROSS'] or env['ON_PEDIGREE']:
@@ -836,13 +851,15 @@ if env['cache']:
 # Make build messages much prettier.
 misc.prettifyBuildMessages(env)
 misc.prettifyBuildMessages(userspace_env)
+misc.prettifyBuildMessages(host_env)
 
 # Generate custom builders and add to environment.
 misc.generate(env)
 misc.generate(userspace_env)
+misc.generate(host_env)
 
 SConscript('SConscript', variant_dir=env['BUILDDIR'],
-           exports=['env', 'userspace_env'], duplicate=0)
+           exports=['env', 'userspace_env', 'host_env'], duplicate=0)
 
 subarch_dump = env.get('SUBARCH_DIR', '')
 if subarch_dump:

--- a/site_scons/buildutils/diskimages/build.py
+++ b/site_scons/buildutils/diskimages/build.py
@@ -42,6 +42,10 @@ def buildDiskImages(env, config_database):
         print 'No disk images being built.'
         return
 
+    # We depend on the ext2img host tool to inject files into ext2 images.
+    ext2img = os.path.join(env['HOST_BUILDDIR'], 'ext2img', 'ext2img')
+    env.Depends(hddimg, ext2img)
+
     env.Depends(hddimg, 'libs')
 
     if env['ARCH_TARGET'] != 'ARM':

--- a/src/buildutil/SConscript
+++ b/src/buildutil/SConscript
@@ -1,0 +1,28 @@
+'''
+Copyright (c) 2008-2014, Pedigree Developers
+
+Please see the CONTRIB file in the root of the source tree for a full
+list of contributors.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+'''
+
+
+import os
+
+Import(['host_env'])
+
+env = host_env
+
+for subdir in ('ext2img',):
+    SConscript(os.path.join(subdir, 'SConscript'), exports=['env'])

--- a/src/buildutil/ext2img/DiskImage.cc
+++ b/src/buildutil/ext2img/DiskImage.cc
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2008-2014, Pedigree Developers
+ *
+ * Please see the CONTRIB file in the root of the source tree for a full
+ * list of contributors.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <BootstrapInfo.h>
+#include <utilities/utility.h>
+#include <Log.h>
+#include "DiskImage.h"
+
+#include <sys/stat.h>
+#include <sys/mman.h>
+
+extern BootstrapStruct_t *g_pBootstrapInfo;
+
+DiskImage::DiskImage(const char *path) : Disk(), m_pFileName(path), m_nSize(0),
+    m_pFile(0), m_pBuffer(0)
+{
+}
+
+DiskImage::~DiskImage()
+{
+    if (m_pBuffer)
+    {
+        msync(m_pBuffer, m_nSize, MS_SYNC);
+        munmap(m_pBuffer, m_nSize);
+    }
+
+    if (m_pFile)
+    {
+        fflush(m_pFile);
+        fclose(m_pFile);
+    }
+}
+
+bool DiskImage::initialise()
+{
+    if (m_pFile)
+        return false;
+
+    m_pFile = fopen(m_pFileName, "rb+");
+    if (!m_pFile)
+        return false;
+
+    int fd = fileno(m_pFile);
+    struct stat st;
+    int r = fstat(fd, &st);
+    if (r < 0)
+    {
+        fclose(m_pFile);
+        m_pFile = 0;
+        return false;
+    }
+
+    m_nSize = st.st_size;
+
+    m_pBuffer = mmap(0, m_nSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (m_pBuffer == MAP_FAILED)
+    {
+        fclose(m_pFile);
+        m_pFile = 0;
+        return false;
+    }
+
+    posix_madvise(m_pBuffer, m_nSize, POSIX_MADV_SEQUENTIAL);
+
+    return true;
+}
+
+uintptr_t DiskImage::read(uint64_t location)
+{
+    if((location > m_nSize) || !m_pFile)
+    {
+        return ~0;
+    }
+
+    return reinterpret_cast<uintptr_t>(m_pBuffer) + location;
+}
+
+void DiskImage::write(uint64_t location)
+{
+    if((location > m_nSize) || !m_pFile)
+    {
+        return;
+    }
+
+    msync(adjust_pointer(m_pBuffer, location), getBlockSize(), MS_ASYNC);
+}
+
+size_t DiskImage::getSize() const
+{
+    return m_nSize;
+}
+
+void DiskImage::pin(uint64_t location)
+{
+}
+
+void DiskImage::unpin(uint64_t location)
+{
+}

--- a/src/buildutil/ext2img/DiskImage.h
+++ b/src/buildutil/ext2img/DiskImage.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2014, Pedigree Developers
+ *
+ * Please see the CONTRIB file in the root of the source tree for a full
+ * list of contributors.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef DISKIMAGE_H
+#define DISKIMAGE_H
+
+#include <machine/Disk.h>
+#include <utilities/Tree.h>
+
+#include <stdio.h>
+
+/** Loads a disk image as a usable disk device. */
+class DiskImage : public Disk
+{
+public:
+    DiskImage(const char *path);
+    virtual ~DiskImage();
+
+    bool initialise();
+
+    virtual void getName(String &str)
+    {
+        str = "Hosted disk image";
+    }
+
+    virtual void dump(String &str)
+    {
+        str = "Hosted disk image";
+    }
+
+    virtual uintptr_t read(uint64_t location);
+    virtual void write(uint64_t location);
+
+    virtual size_t getSize() const;
+
+    virtual size_t getBlockSize() const
+    {
+        return 4096;
+    }
+
+    virtual void pin(uint64_t location);
+
+    virtual void unpin(uint64_t location);
+
+private:
+    const char *m_pFileName;
+    size_t m_nSize;
+    FILE *m_pFile;
+
+    void *m_pBuffer;
+};
+
+#endif

--- a/src/buildutil/ext2img/SConscript
+++ b/src/buildutil/ext2img/SConscript
@@ -1,0 +1,102 @@
+'''
+Copyright (c) 2008-2014, Pedigree Developers
+
+Please see the CONTRIB file in the root of the source tree for a full
+list of contributors.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+'''
+
+
+import os
+
+Import(['env'])
+
+EXT2_DIR = env.Dir('#src/modules/system/ext2').abspath
+VFS_DIR = env.Dir('#src/modules/system/vfs').abspath
+PART_DIR = env.Dir('#src/modules/drivers/common/partition').abspath
+KERNEL_DIR = env.Dir('#src/system/kernel').abspath
+
+build_env = env.Clone()
+
+# Set up includes correctly.
+header_paths = [
+    env.Dir('#src/modules/system'),
+    env.Dir('#src/system/include'),
+]
+
+build_env.Append(CPPPATH=header_paths)
+
+# Create a fake build environment (TODO: detect host architecture)
+defines = [
+    'HOSTED', 'VFS_NOMMU', 'VFS_STANDALONE', 'EXT2_STANDALONE',
+    'UTILITY_LINUX', 'NO_LOGGING', 'DEVICE_IGNORE_ADDRESSES',
+    'LITTLE_ENDIAN',
+    # On Pedigree, memcpy automatically determines if it should fall back to
+    # memmove for backwards copies - not so on other systems. So, just
+    # make memcpy the same as memmove.
+    'memcpy=memmove',
+]
+
+build_env.Append(CPPDEFINES=defines)
+
+build_env.MergeFlags({'CXXFLAGS': ['-std=c++11', '-g3', '-ggdb', '-O2']})
+
+# VFS module sources that we care about.
+vfs_sources = [
+    'File.cc',
+    'Filesystem.cc',
+    'VFS.cc',
+    'Symlink.cc',
+    'Directory.cc',
+]
+
+# ext2 module sources that we care about.
+ext2_sources = [
+    'Ext2Directory.cc',
+    'Ext2Filesystem.cc',
+    'Ext2File.cc',
+    'Ext2Node.cc',
+    'Ext2Symlink.cc',
+]
+
+# partition module sources that we care about.
+partition_sources = [
+    'Partition.cc',
+    'apple.cc',
+    'msdos.cc',
+]
+
+# base kernel sources that we care about.
+kernel_sources = [
+    os.path.join('utilities', 'String.cc'),
+    os.path.join('utilities', 'List.cc'),
+    os.path.join('utilities', 'Vector.cc'),
+    os.path.join('utilities', 'Tree.cc'),
+    os.path.join('machine', 'Device.cc'),
+]
+
+# Build components from Pedigree to merge into a working VFS layer that uses
+# an ext2 filesystem.
+libvfs = build_env.Library('vfs',
+    [os.path.join(VFS_DIR, f) for f in vfs_sources])
+libext2 = build_env.Library('ext2',
+    [os.path.join(EXT2_DIR, f) for f in ext2_sources])
+libpart = build_env.Library('part',
+    [os.path.join(PART_DIR, f) for f in partition_sources])
+libkern = build_env.Library('kern',
+    [os.path.join(KERNEL_DIR, f) for f in kernel_sources])
+
+
+build_env.Program('ext2img', ['main.cc', 'DiskImage.cc'],
+    LIBS=[libext2, libvfs, libpart, libkern])

--- a/src/buildutil/ext2img/main.cc
+++ b/src/buildutil/ext2img/main.cc
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2008-2014, Pedigree Developers
+ *
+ * Please see the CONTRIB file in the root of the source tree for a full
+ * list of contributors.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <stdlib.h>
+
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <vfs/VFS.h>
+#include <vfs/File.h>
+#include <vfs/Directory.h>
+#include <vfs/Symlink.h>
+#include <ext2/Ext2Filesystem.h>
+#include <machine/Disk.h>
+#include <utilities/String.h>
+
+#include "DiskImage.h"
+
+#define FS_ALIAS "fs"
+#define TO_FS_PATH(x) String(FS_ALIAS "»") += x.c_str()
+
+static bool ignoreErrors = false;
+static size_t blocksPerRead = 64;
+
+enum CommandType
+{
+    InvalidCommand,
+    CreateDirectory,
+    CreateSymlink,
+    WriteFile,
+};
+
+struct Command
+{
+    Command() : what(InvalidCommand), params() {};
+
+    CommandType what;
+    std::vector<std::string> params;
+};
+
+extern bool msdosProbeDisk(Disk *pDisk);
+extern bool appleProbeDisk(Disk *pDisk);
+
+void syscallError(int e)
+{
+    std::cerr << "ERROR: #" << e << std::endl;
+}
+
+uint32_t getUnixTimestamp()
+{
+    return time(0);
+}
+
+bool writeFile(std::string source, std::string dest)
+{
+    std::ifstream ifs(source, std::ios::binary);
+    if (ifs.bad() || ifs.fail())
+    {
+        std::cerr << "Could not open source file '" << source << "'." << std::endl;
+        return false;
+    }
+
+    bool result = VFS::instance().createFile(TO_FS_PATH(dest), 0644);
+    if (!result)
+    {
+        std::cerr << "Could not create destination file '" << dest << "'." << std::endl;
+        return false;
+    }
+
+    File *pFile = VFS::instance().find(TO_FS_PATH(dest));
+    if (!pFile)
+    {
+        std::cerr << "Couldn't open created destination file: '" << dest << "'." << std::endl;
+        return false;
+    }
+
+    size_t blockSize = pFile->getBlockSize() * blocksPerRead;
+
+    char *buffer = new char[blockSize];
+
+    uint64_t offset = 0;
+    while (!ifs.eof())
+    {
+        ifs.read(buffer, blockSize);
+        uint64_t readCount = ifs.gcount();
+        uint64_t count = 0;
+        if (readCount)
+        {
+            count = pFile->write(offset, readCount, reinterpret_cast<uintptr_t>(buffer));
+            if (!count || (count < readCount))
+            {
+                std::cerr << "Empty or short write to file '" << dest << "'." << std::endl;
+                if (!ignoreErrors)
+                    return false;
+            }
+
+            offset += readCount;
+        }
+    }
+
+    return true;
+}
+
+bool createSymlink(std::string name, std::string target)
+{
+    bool result = VFS::instance().createSymlink(TO_FS_PATH(name), String(target.c_str()));
+    if (!result)
+    {
+        std::cerr << "Could not create symlink '" << name << "' -> '" << target << "'." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+bool createDirectory(std::string dest)
+{
+    bool result = VFS::instance().createDirectory(TO_FS_PATH(dest));
+    if (!result)
+    {
+        std::cerr << "Could not create directory '" << dest << "'." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+int handleImage(const char *image, std::vector<Command> &cmdlist, size_t part=0)
+{
+    // Prepare to probe ext2 filesystems via the VFS.
+    VFS::instance().addProbeCallback(&Ext2Filesystem::probe);
+
+    DiskImage mainImage(image);
+    if (!mainImage.initialise())
+    {
+        std::cerr << "Couldn't load disk image!" << std::endl;
+        return 1;
+    }
+
+    bool isFullFilesystem = false;
+    if (!msdosProbeDisk(&mainImage))
+    {
+        std::cerr << "No MSDOS partition table found, trying an Apple partition table." << std::endl;
+        if (!appleProbeDisk(&mainImage))
+        {
+            std::cerr << "No partition table found, assuming this is an ext2 filesystem." << std::endl;
+            isFullFilesystem = true;
+        }
+    }
+
+    size_t desiredPartition = part;
+
+    Disk *pDisk = 0;
+
+    if (isFullFilesystem)
+        pDisk = &mainImage;
+    else
+    {
+        // Find the nth partition.
+        if (desiredPartition > mainImage.getNumChildren())
+        {
+            std::cerr << "Desired partition does not exist in this image." << std::endl;
+            return 1;
+        }
+
+        pDisk = static_cast<Disk *>(mainImage.getChild(desiredPartition));
+    }
+
+    // Make sure we actually have a filesystem here.
+    String alias("fs");
+    if (!VFS::instance().mount(pDisk, alias))
+    {
+        std::cerr << "This partition does not appear to be an ext2 filesystem." << std::endl;
+        return 1;
+    }
+
+    // Handle the command list.
+    size_t nth = 0;
+    for (auto it = cmdlist.begin(); it != cmdlist.end(); ++it, ++nth)
+    {
+        switch (it->what)
+        {
+            case WriteFile:
+                if ((!writeFile(it->params[0], it->params[1])) && !ignoreErrors)
+                {
+                    return 1;
+                }
+                break;
+            case CreateSymlink:
+                if ((!createSymlink(it->params[0], it->params[1])) && !ignoreErrors)
+                {
+                    return 1;
+                }
+                break;
+            case CreateDirectory:
+                if ((!createDirectory(it->params[0])) && !ignoreErrors)
+                {
+                    return 1;
+                }
+                break;
+            default:
+                std::cerr << "Unknown command in command list." << std::endl;
+                break;
+        }
+
+        if ((nth % 10) == 0)
+        {
+            double progress = nth / (double) cmdlist.size();
+            std::cout << "Progress: " << std::setprecision(4) << (progress * 100.0) << "%      \r" << std::flush;
+        }
+    }
+
+    std::cout << "\rProgress: 100.0%" << std::endl;
+
+    std::cout << "Completed command list for image " << image << "." << std::endl;
+}
+
+bool parseCommandFile(const char *cmdFile, std::vector<Command> &output)
+{
+    std::ifstream f(cmdFile);
+    if (f.bad() || f.fail())
+    {
+        std::cerr << "Command file '" << cmdFile << "' could not be read." << std::endl;
+        return false;
+    }
+
+    std::string line;
+    size_t lineno = 0;
+    while (std::getline(f, line))
+    {
+        ++lineno;
+
+        if (line.empty())
+        {
+            continue;
+        }
+
+        if (line[0] == '#')
+        {
+            // Comment line.
+            continue;
+        }
+
+        Command c;
+        std::istringstream s(line);
+
+        std::string cmd;
+        s >> cmd;
+
+        std::string next;
+        while (s >> next)
+        {
+            if (next.empty())
+            {
+                continue;
+            }
+
+            c.params.push_back(next);
+        }
+
+        size_t requiredParamCount = 0;
+
+        bool ok = true;
+
+        if (cmd == "write")
+        {
+            c.what = WriteFile;
+            requiredParamCount = 2;
+        }
+        else if (cmd == "symlink")
+        {
+            c.what = CreateSymlink;
+            requiredParamCount = 2;
+        }
+        else if (cmd == "mkdir")
+        {
+            c.what = CreateDirectory;
+            requiredParamCount = 1;
+        }
+        else
+        {
+            std::cerr << "Unknown command '" << cmd << "' at line " << lineno << ": '" << line << "'" << std::endl;
+            ok = false;
+        }
+
+        if (c.params.size() < requiredParamCount)
+        {
+            std::cerr << "Not enough parameters for '" << cmd << "' at line " << lineno << ": '" << line << "'" << std::endl;
+            ok = false;
+        }
+
+        if (!ok)
+        {
+            if (!ignoreErrors)
+                return false;
+
+            continue;
+        }
+
+        output.push_back(c);
+    }
+
+    return true;
+}
+
+int main(int argc, char *argv[])
+{
+    const char *cmdFile = 0;
+    const char *diskImage = 0;
+    size_t partitionNumber = 0;
+
+    // Load options.
+    int c;
+    while ((c = getopt(argc, argv, "if:c:p::b:")) != -1)
+    {
+        switch (c)
+        {
+            case 'c':
+                // cmdfile
+                cmdFile = optarg;
+                break;
+            case 'f':
+                // disk image
+                diskImage = optarg;
+                break;
+            case 'i':
+                ignoreErrors = true;
+                break;
+            case 'p':
+                // partition number
+                partitionNumber = atoi(optarg);
+                break;
+            case 'b':
+                // # of blocks per read.
+                blocksPerRead = atoi(optarg);
+                break;
+            case '?':
+                if (optopt == 'c' || optopt == 'p')
+                {
+                    std::cerr << "Option -" << optopt << " requires an argument." << std::endl;
+                }
+                else
+                {
+                    std::cerr << "Option -" << optopt << " is unknown." << std::endl;
+                }
+                break;
+            default:
+                return 1;
+        }
+    }
+
+    if (cmdFile == 0)
+    {
+        std::cerr << "A command file must be specified." << std::endl;
+        return 1;
+    }
+
+    if (diskImage == 0)
+    {
+        std::cerr << "A disk image must be specified." << std::endl;
+        return 1;
+    }
+
+    // Parse!
+    std::vector<Command> cmdlist;
+    if (!parseCommandFile(cmdFile, cmdlist))
+    {
+        return 1;
+    }
+
+    // Complete tasks.
+    int rc = handleImage(diskImage, cmdlist, partitionNumber);
+    std::cout << std::flush;
+    return rc;
+}

--- a/src/modules/drivers/common/partition/msdos.cc
+++ b/src/modules/drivers/common/partition/msdos.cc
@@ -21,15 +21,17 @@
 #include <processor/Processor.h>
 #include <Log.h>
 #include "Partition.h"
-#include <Spinlock.h>
 #include <LockGuard.h>
+
+#ifdef THREADS
+#include <Spinlock.h>
+Spinlock g_Lock;
+#endif
 
 // Partition number for a DOS extended partition (another partition table)
 const uint8_t g_ExtendedPartitionNumber = 5;
 // Partition number for an empty partition.
 const uint8_t g_EmptyPartitionNumber = 0;
-
-Spinlock g_Lock;
 
 const char *g_pPartitionTypes[256] = {
     "Empty",
@@ -295,7 +297,9 @@ static int gNextPartition = 0;
 
 void msdosRegPartition(MsdosPartitionInfo *pPartitions, int i, Disk *pDisk)
 {
+#ifdef THREADS
     LockGuard<Spinlock> guard(g_Lock);
+#endif
 
     // Look up the partition string.
     const char *pStr = g_pPartitionTypes[pPartitions[i].type];

--- a/src/modules/drivers/common/scsi/ScsiDisk.cc
+++ b/src/modules/drivers/common/scsi/ScsiDisk.cc
@@ -35,19 +35,19 @@
 #define SCSI_DEBUG_LOG(...)
 #endif
 
-void ScsiDisk::cacheCallback(Cache::CallbackCause cause, uintptr_t loc, uintptr_t page, void *meta)
+void ScsiDisk::cacheCallback(CacheConstants::CallbackCause cause, uintptr_t loc, uintptr_t page, void *meta)
 {
     ScsiDisk *pDisk = reinterpret_cast<ScsiDisk *>(meta);
 
     switch(cause)
     {
-        case Cache::WriteBack:
+        case CacheConstants::WriteBack:
             {
                 // Blocking write request.
                 pDisk->flush(loc);
             }
             break;
-        case Cache::Eviction:
+        case CacheConstants::Eviction:
             // no-op for ScsiDisk
             break;
         default:

--- a/src/modules/drivers/common/scsi/ScsiDisk.h
+++ b/src/modules/drivers/common/scsi/ScsiDisk.h
@@ -149,7 +149,7 @@ class ScsiDisk : public Disk
 
         bool getCapacityInternal(size_t *blockNumber, size_t *blockSize);
 
-        static void cacheCallback(Cache::CallbackCause cause, uintptr_t loc, uintptr_t page, void *meta);
+        static void cacheCallback(CacheConstants::CallbackCause cause, uintptr_t loc, uintptr_t page, void *meta);
 
         class ScsiController* m_pController;
         size_t m_nUnit;

--- a/src/modules/system/console/Console.cc
+++ b/src/modules/system/console/Console.cc
@@ -21,6 +21,7 @@
 #include <vfs/VFS.h>
 #include <Module.h>
 
+#include <processor/Processor.h>
 #include <process/Scheduler.h>
 
 // c_cc array indices, and their default character.

--- a/src/modules/system/ext2/Ext2Directory.cc
+++ b/src/modules/system/ext2/Ext2Directory.cc
@@ -305,7 +305,7 @@ void Ext2Directory::cacheDirectoryContents()
 
             }
 
-            size_t namelen = pDir->d_namelen + 1;
+            size_t namelen = pDir->d_namelen;
 
             uint32_t inodeNum = LITTLE_TO_HOST32(pDir->d_inode);
             Inode *inode = m_pExt2Fs->getInode(inodeNum);

--- a/src/modules/system/ext2/Ext2Directory.cc
+++ b/src/modules/system/ext2/Ext2Directory.cc
@@ -373,7 +373,7 @@ void Ext2Directory::cacheDirectoryContents()
         m_pExt2Fs->unpinBlock(m_pBlocks[i]);
     }
 
-    m_bCachePopulated = true;
+    markCachePopulated();
 }
 
 void Ext2Directory::fileAttributeChanged()

--- a/src/modules/system/ext2/Ext2Filesystem.cc
+++ b/src/modules/system/ext2/Ext2Filesystem.cc
@@ -43,8 +43,13 @@ uint8_t g_pSparseBlock[4096] ALIGN(4096) __attribute__((__section__(".bss")));
 
 
 Ext2Filesystem::Ext2Filesystem() :
-    m_pSuperblock(0), m_pGroupDescriptors(), m_BlockSize(0), m_InodeSize(0),
-    m_nGroupDescriptors(0), m_WriteLock(false), m_pRoot(0)
+    m_pSuperblock(0), m_pGroupDescriptors(0), m_pInodeTables(0),
+    m_pInodeBitmaps(0), m_pBlockBitmaps(0), m_BlockSize(0), m_InodeSize(0),
+    m_nGroupDescriptors(0),
+#ifdef THREADS
+    m_WriteLock(false),
+#endif
+    m_pRoot(0)
 {
 }
 

--- a/src/modules/system/ext2/Ext2Filesystem.cc
+++ b/src/modules/system/ext2/Ext2Filesystem.cc
@@ -84,7 +84,7 @@ bool Ext2Filesystem::initialise(Disk *pDisk)
     // Attempt to read the superblock.
     // We need to pin the block, as we'll hold onto it.
     uintptr_t block = m_pDisk->read(1024ULL);
-    if (!block || block == ~0ULL)
+    if (!block || block == ~static_cast<uintptr_t>(0U))
     {
         return false;
     }

--- a/src/modules/system/ext2/Ext2Filesystem.h
+++ b/src/modules/system/ext2/Ext2Filesystem.h
@@ -115,8 +115,10 @@ private:
     /** Number of group descriptors. */
     size_t m_nGroupDescriptors;
 
+#ifdef THREADS
     /** Write lock - we're finding some inodes and updating the superblock and block group structures. */
     Mutex m_WriteLock;
+#endif
 
     /** The root filesystem node. */
     File *m_pRoot;

--- a/src/modules/system/ext2/Ext2Node.cc
+++ b/src/modules/system/ext2/Ext2Node.cc
@@ -156,7 +156,7 @@ bool Ext2Node::ensureLargeEnough(size_t size)
 
 bool Ext2Node::ensureBlockLoaded(size_t nBlock)
 {
-    if (nBlock >= m_nBlocks)
+    if (nBlock > m_nBlocks)
     {
         FATAL("EXT2: ensureBlockLoaded: Algorithmic error [block " << nBlock << " > " << m_nBlocks << "].");
     }
@@ -351,6 +351,11 @@ bool Ext2Node::addBlock(uint32_t blockValue)
 
         // Grab the indirect block.
         pBlock = reinterpret_cast<uint32_t*>(m_pExt2Fs->readBlock(nIndirectBlockNum));
+        if (pBlock == reinterpret_cast<uint32_t *>(~0))
+        {
+            ERROR("Could not read block that we wanted to add.");
+            return false;
+        }
 
         // Set the correct entry.
         pBlock[indirectIdx] = HOST_TO_LITTLE32(blockValue);

--- a/src/modules/system/network-stack/RawManager.cc
+++ b/src/modules/system/network-stack/RawManager.cc
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -23,6 +22,7 @@
 #include "NetManager.h"
 #include <Log.h>
 #include <syscallError.h>
+#include <processor/Processor.h>
 
 #include "Ipv4.h"
 

--- a/src/modules/system/network-stack/RoutingTable.h
+++ b/src/modules/system/network-stack/RoutingTable.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -28,6 +27,7 @@
 #include <process/Semaphore.h>
 #include <machine/Network.h>
 #include <config/Config.h>
+#include <process/Mutex.h>
 
 /**
  * The Pedigree routing table supports three different ways to route packets:

--- a/src/modules/system/preload/main.cc
+++ b/src/modules/system/preload/main.cc
@@ -21,6 +21,7 @@
 #include <Module.h>
 #include <vfs/VFS.h>
 #include <vfs/Filesystem.h>
+#include <processor/Processor.h>
 #include <process/Semaphore.h>
 #include <process/Scheduler.h>
 #include <vfs/MemoryMappedFile.h>

--- a/src/modules/system/vfs/Directory.cc
+++ b/src/modules/system/vfs/Directory.cc
@@ -75,3 +75,13 @@ size_t Directory::getNumChildren()
 void Directory::cacheDirectoryContents()
 {
 }
+
+File *Directory::lookup(String &s) const
+{
+    if (!m_bCachePopulated)
+    {
+        return 0;
+    }
+
+    return m_Cache.lookup(s);
+}

--- a/src/modules/system/vfs/Directory.h
+++ b/src/modules/system/vfs/Directory.h
@@ -73,10 +73,7 @@ public:
     }
 
     /** Look up the given filename in the directory. */
-    File *lookup(String &s) const
-    {
-        return m_Cache.lookup(s);
-    }
+    File *lookup(String &s) const;
 
     /** Remove the given filename in the directory. */
     void remove(String &s)
@@ -93,6 +90,12 @@ protected:
     virtual RadixTree<File *> &getCache()
     {
         return m_Cache;
+    }
+
+    /** Mark the directory cache as populated now. */
+    void markCachePopulated()
+    {
+        m_bCachePopulated = true;
     }
 
     /**

--- a/src/modules/system/vfs/File.cc
+++ b/src/modules/system/vfs/File.cc
@@ -25,13 +25,13 @@
 #include <process/Scheduler.h>
 #include <Log.h>
 
-void File::writeCallback(Cache::CallbackCause cause, uintptr_t loc, uintptr_t page, void *meta)
+void File::writeCallback(CacheConstants::CallbackCause cause, uintptr_t loc, uintptr_t page, void *meta)
 {
     File *pFile = reinterpret_cast<File *>(meta);
 
     switch(cause)
     {
-        case Cache::WriteBack:
+        case CacheConstants::WriteBack:
             {
                 pFile->m_Lock.acquire();
 
@@ -45,7 +45,7 @@ void File::writeCallback(Cache::CallbackCause cause, uintptr_t loc, uintptr_t pa
                 pFile->m_Lock.release();
             }
             break;
-        case Cache::Eviction:
+        case CacheConstants::Eviction:
             // Remove this page from our data cache.
             // Side-effect: if the block size is larger than the page size, the
             // entire block will be removed. Is this something we care about?

--- a/src/modules/system/vfs/File.cc
+++ b/src/modules/system/vfs/File.cc
@@ -202,6 +202,7 @@ uint64_t File::write(uint64_t location, uint64_t size, uintptr_t buffer, bool bC
 
 physical_uintptr_t File::getPhysicalPage(size_t offset)
 {
+#ifndef VFS_NOMMU
     // Sanitise input.
     size_t blockSize = getBlockSize();
     offset &= ~(blockSize - 1);
@@ -238,12 +239,14 @@ physical_uintptr_t File::getPhysicalPage(size_t offset)
 
         return phys;
     }
+#endif
 
     return ~0UL;
 }
 
 void File::returnPhysicalPage(size_t offset)
 {
+#ifndef VFS_NOMMU
     // Sanitise input.
     size_t blockSize = getBlockSize();
     offset &= ~(blockSize - 1);
@@ -263,6 +266,7 @@ void File::returnPhysicalPage(size_t offset)
 #ifdef THREADS
     m_Lock.release();
 #endif
+#endif  // VFS_NOMMU
 }
 
 void File::sync()

--- a/src/modules/system/vfs/File.cc
+++ b/src/modules/system/vfs/File.cc
@@ -22,6 +22,7 @@
 #include "Symlink.h"
 #include "Filesystem.h"
 #include <processor/Processor.h>
+#include <processor/types.h>
 #include <process/Scheduler.h>
 #include <Log.h>
 
@@ -33,7 +34,9 @@ void File::writeCallback(CacheConstants::CallbackCause cause, uintptr_t loc, uin
     {
         case CacheConstants::WriteBack:
             {
-                pFile->m_Lock.acquire();
+#ifdef THREADS
+                LockGuard<Mutex>(pFile->m_Lock);
+#endif
 
                 // We are given one dirty page. Blocks can be smaller than a page.
                 size_t off = 0;
@@ -41,8 +44,6 @@ void File::writeCallback(CacheConstants::CallbackCause cause, uintptr_t loc, uin
                 {
                     pFile->writeBlock(loc + off, page + off);
                 }
-
-                pFile->m_Lock.release();
             }
             break;
         case CacheConstants::Eviction:
@@ -61,7 +62,10 @@ File::File() :
     m_Name(""), m_AccessedTime(0), m_ModifiedTime(0),
     m_CreationTime(0), m_Inode(0), m_pFilesystem(0), m_Size(0),
     m_pParent(0), m_nWriters(0), m_nReaders(0), m_Uid(0), m_Gid(0),
-    m_Permissions(0), m_DataCache(), m_Lock(), m_MonitorTargets()
+    m_Permissions(0), m_DataCache()
+#ifdef THREADS
+    , m_Lock(), m_MonitorTargets()
+#endif
 {
 }
 
@@ -70,7 +74,10 @@ File::File(String name, Time::Timestamp accessedTime, Time::Timestamp modifiedTi
     m_Name(name), m_AccessedTime(accessedTime), m_ModifiedTime(modifiedTime),
     m_CreationTime(creationTime), m_Inode(inode), m_pFilesystem(pFs),
     m_Size(size), m_pParent(pParent), m_nWriters(0), m_nReaders(0), m_Uid(0),
-    m_Gid(0), m_Permissions(0), m_DataCache(), m_Lock(), m_MonitorTargets()
+    m_Gid(0), m_Permissions(0), m_DataCache()
+#ifdef THREADS
+    , m_Lock(), m_MonitorTargets()
+#endif
 {
 }
 
@@ -109,7 +116,9 @@ uint64_t File::read(uint64_t location, uint64_t size, uintptr_t buffer, bool bCa
         if(sz > (m_Size - location))
             sz = m_Size - location;
 
+#ifdef THREADS
         m_Lock.acquire();
+#endif
         uintptr_t buff = m_DataCache.lookup(block*blockSize);
         if (!buff)
         {
@@ -121,7 +130,9 @@ uint64_t File::read(uint64_t location, uint64_t size, uintptr_t buffer, bool bCa
             }
             m_DataCache.insert(block*blockSize, buff);
         }
+#ifdef THREADS
         m_Lock.release();
+#endif
 
         if(buffer)
         {
@@ -151,7 +162,9 @@ uint64_t File::write(uint64_t location, uint64_t size, uintptr_t buffer, bool bC
         uintptr_t offs  = location % blockSize;
         uintptr_t sz    = (size+offs > blockSize) ? blockSize-offs : size;
 
+#ifdef THREADS
         m_Lock.acquire();
+#endif
         uintptr_t buff = m_DataCache.lookup(block*blockSize);
         if (!buff)
         {
@@ -163,7 +176,9 @@ uint64_t File::write(uint64_t location, uint64_t size, uintptr_t buffer, bool bC
             }
             m_DataCache.insert(block*blockSize, buff);
         }
+#ifdef THREADS
         m_Lock.release();
+#endif
 
         memcpy(reinterpret_cast<void*>(buff+offs),
                reinterpret_cast<void*>(buffer),
@@ -198,9 +213,13 @@ physical_uintptr_t File::getPhysicalPage(size_t offset)
     }
 
     // Check if we have this page in the cache.
+#ifdef THREADS
     m_Lock.acquire();
+#endif
     uintptr_t vaddr = m_DataCache.lookup(offset);
+#ifdef THREADS
     m_Lock.release();
+#endif
     if (!vaddr)
     {
         return ~0UL;
@@ -237,9 +256,13 @@ void File::returnPhysicalPage(size_t offset)
 
     // Release the page. Beware - this could cause a cache evict, which will
     // make the next read/write at this offset do real (slow) I/O.
+#ifdef THREADS
     m_Lock.acquire();
+#endif
     unpinBlock(offset);
+#ifdef THREADS
     m_Lock.release();
+#endif
 }
 
 void File::sync()
@@ -311,6 +334,7 @@ void File::truncate()
 
 void File::dataChanged()
 {
+#ifdef THREADS
     m_Lock.acquire();
 
     bool bAny = false;
@@ -334,8 +358,10 @@ void File::dataChanged()
     {
         Scheduler::instance().yield();
     }
+#endif
 }
 
+#ifdef THREADS
 void File::cullMonitorTargets(Thread *pThread)
 {
     LockGuard<Mutex> guard(m_Lock);
@@ -356,6 +382,7 @@ void File::cullMonitorTargets(Thread *pThread)
         }
     }
 }
+#endif
 
 void File::getFilesystemLabel(HugeStaticString &s)
 {

--- a/src/modules/system/vfs/File.h
+++ b/src/modules/system/vfs/File.h
@@ -226,6 +226,7 @@ public:
     /** Causes the event pEvent to be dispatched to pThread when activity occurs
         on this File. Activity includes the file becoming available for reading,
         writing or erroring. */
+#ifdef THREADS
     void monitor(Thread *pThread, Event *pEvent)
     {
         m_Lock.acquire();
@@ -235,6 +236,7 @@ public:
 
     /** Walks the monitor-target queue, removing all for \p pThread .*/
     void cullMonitorTargets(Thread *pThread);
+#endif
 
     /** Does this File object support the given integer-based command? */
     virtual bool supports(const int command)
@@ -320,7 +322,9 @@ protected:
      */
     void evict(uint64_t location)
     {
+#ifdef THREADS
         LockGuard<Mutex> guard(m_Lock);
+#endif
         m_DataCache.remove(location);
     }
 
@@ -361,6 +365,7 @@ protected:
 
     Tree<uint64_t,size_t> m_DataCache;
 
+#ifdef THREADS
     Mutex m_Lock;
 
     struct MonitorTarget
@@ -373,6 +378,7 @@ protected:
     };
 
     List<MonitorTarget*> m_MonitorTargets;
+#endif
 };
 
 #endif

--- a/src/modules/system/vfs/File.h
+++ b/src/modules/system/vfs/File.h
@@ -26,7 +26,9 @@
 #include <utilities/RadixTree.h>
 #include <process/Thread.h>
 #include <process/Event.h>
-#include <utilities/Cache.h>
+#include <utilities/CacheConstants.h>
+#include <utilities/Tree.h>
+#include <LockGuard.h>
 
 #include <processor/PhysicalMemoryManager.h>
 
@@ -286,7 +288,7 @@ protected:
      * as the callback on their Cache instance to get a write-back
      * notification.
      */
-    static void writeCallback(Cache::CallbackCause cause, uintptr_t loc, uintptr_t page, void *meta);
+    static void writeCallback(CacheConstants::CallbackCause cause, uintptr_t loc, uintptr_t page, void *meta);
 
     /**
      * Pins the given page.

--- a/src/modules/system/vfs/Filesystem.cc
+++ b/src/modules/system/vfs/Filesystem.cc
@@ -40,10 +40,12 @@ Filesystem::Filesystem() :
 
 File *Filesystem::getTrueRoot()
 {
+#ifdef THREADS
     Process *pProcess = Processor::information().getCurrentThread()->getParent();
     File *maybeRoot = pProcess->getRootFile();
     if (maybeRoot)
         return maybeRoot;
+#endif
     return getRoot();
 }
 

--- a/src/modules/system/vfs/LockedFile.cc
+++ b/src/modules/system/vfs/LockedFile.cc
@@ -18,6 +18,7 @@
  */
 
 #include "LockedFile.h"
+#include <processor/Processor.h>
 #include <Log.h>
 
 LockedFile::LockedFile(File *pFile) : m_File(pFile), m_bLocked(false), m_LockerPid(0), m_Lock(false)

--- a/src/modules/system/vfs/LockedFile.cc
+++ b/src/modules/system/vfs/LockedFile.cc
@@ -21,23 +21,32 @@
 #include <processor/Processor.h>
 #include <Log.h>
 
-LockedFile::LockedFile(File *pFile) : m_File(pFile), m_bLocked(false), m_LockerPid(0), m_Lock(false)
+LockedFile::LockedFile(File *pFile) : m_File(pFile), m_bLocked(false), m_LockerPid(0)
+#ifdef THREADS
+    , m_Lock(false)
+#endif
 {};
 
-LockedFile::LockedFile(LockedFile &c) : m_File(0), m_bLocked(false), m_LockerPid(0), m_Lock(false)
+LockedFile::LockedFile(LockedFile &c) : m_File(0), m_bLocked(false), m_LockerPid(0)
+#ifdef THREADS
+    , m_Lock(false)
+#endif
 {
     m_File = c.m_File;
     m_bLocked = c.m_bLocked;
     m_LockerPid = c.m_LockerPid;
 
+#ifdef THREADS
     if(m_bLocked)
     {
         m_Lock.acquire();
     }
+#endif
 }
 
 bool LockedFile::lock(bool bBlock)
 {
+#ifdef THREADS
     if(!bBlock)
     {
         if(!m_Lock.tryAcquire())
@@ -51,32 +60,39 @@ bool LockedFile::lock(bool bBlock)
     // Obtained the lock
     m_bLocked = true;
     m_LockerPid = Processor::information().getCurrentThread()->getParent()->getId();
+#endif
     return true;
 }
 
 void LockedFile::unlock()
 {
+#ifdef THREADS
     if(m_bLocked)
     {
         m_bLocked = false;
         m_Lock.release();
     }
+#endif
 }
 
 File *LockedFile::getFile()
 {
+#ifdef THREADS
     // If we're locked, and we aren't the locking process, we can't access the file
     // Otherwise, the file is accessible
     if(m_bLocked == true && Processor::information().getCurrentThread()->getParent()->getId() != m_LockerPid)
         return 0;
     else
+#endif
         return m_File;
 }
 
 size_t LockedFile::getLocker()
 {
+#ifdef THREADS
     if(m_bLocked)
         return m_LockerPid;
     else
+#endif
         return 0;
 }

--- a/src/modules/system/vfs/LockedFile.h
+++ b/src/modules/system/vfs/LockedFile.h
@@ -77,7 +77,9 @@ private:
     size_t m_LockerPid;
 
     /** Our lock */
+#ifdef THREADS
     Mutex m_Lock;
+#endif
 };
 
 #endif

--- a/src/modules/system/vfs/MemoryMappedFile.cc
+++ b/src/modules/system/vfs/MemoryMappedFile.cc
@@ -19,6 +19,7 @@
 
 #include "MemoryMappedFile.h"
 
+#include <processor/Processor.h>
 #include <processor/PhysicalMemoryManager.h>
 #include <process/MemoryPressureManager.h>
 #include <Spinlock.h>

--- a/src/modules/system/vfs/Pipe.cc
+++ b/src/modules/system/vfs/Pipe.cc
@@ -19,6 +19,7 @@
 
 #include "Pipe.h"
 #include "Filesystem.h"
+#include <processor/Processor.h>
 #include <utilities/ZombieQueue.h>
 
 class ZombiePipe : public ZombieObject

--- a/src/modules/system/vfs/VFS.h
+++ b/src/modules/system/vfs/VFS.h
@@ -1,5 +1,4 @@
 /*
- * 
  * Copyright (c) 2008-2014, Pedigree Developers
  *
  * Please see the CONTRIB file in the root of the source tree for a full
@@ -76,7 +75,7 @@ public:
     {
         return m_Aliases;
     }
-    
+
     /** Obtains a list of all mounted filesystems */
     inline Tree<Filesystem *, List<String*>* > &getMounts()
     {

--- a/src/system/include/Log.h
+++ b/src/system/include/Log.h
@@ -20,7 +20,9 @@
 #ifndef KERNEL_LOG_H
 #define KERNEL_LOG_H
 
+#ifdef THREADS
 #include <Spinlock.h>
+#endif
 #include <processor/types.h>
 #include <utilities/String.h>
 #include <utilities/Vector.h>
@@ -176,7 +178,9 @@ public:
 
   /** The lock
    *\note this should only be acquired by the NOTICE, WARNING, ERROR and FATAL macros */
+#ifdef THREADS
   Spinlock m_Lock;
+#endif
 
   /** Retrieves the static Log instance.
    *\return instance of the log class */

--- a/src/system/include/Log.h
+++ b/src/system/include/Log.h
@@ -32,6 +32,14 @@
 
 #define SHOW_FILE_IN_LOGS 0
 
+#ifdef THREADS
+#define LOG_LOCK_ACQUIRE Log::instance().m_Lock.acquire()
+#define LOG_LOCK_RELEASE Log::instance().m_Lock.release()
+#else
+#define LOG_LOCK_ACQUIRE do { } while(0)
+#define LOG_LOCK_RELEASE do { } while(0)
+#endif
+
 #if SHOW_FILE_IN_LOGS
 #define FILE_LOG(level) \
   do \
@@ -42,118 +50,62 @@
 #define FILE_LOG(level)
 #endif
 
-/** Add a debug item to the log */
-#ifdef DEBUG_LOGGING
-#define DEBUG_LOG(text) \
+#define LOG_AT_LEVEL(level, text, lock) \
   do \
   { \
-    Log::instance().m_Lock.acquire(); \
-    FILE_LOG(Log::Debug); \
-    Log::instance() << Log::Debug << text << Flush; \
-    Log::instance().m_Lock.release(); \
+    if (lock) \
+      LOG_LOCK_ACQUIRE; \
+    FILE_LOG(level); \
+    Log::instance() << level << text << Flush; \
+    if (lock) \
+      LOG_LOCK_RELEASE; \
   } \
   while (0)
 
-#define DEBUG_LOG_NOLOCK(text) \
-  do \
-  { \
-    FILE_LOG(Log::Debug); \
-    Log::instance() << Log::Debug << text << Flush; \
-  } \
-  while (0)
+#ifndef NO_LOGGING
+
+/** Add a debug item to the log */
+#ifdef DEBUG_LOGGING
+#define DEBUG_LOG(text) LOG_AT_LEVEL(Log::Debug, text, 1)
+#define DEBUG_LOG_NOLOCK(text) LOG_AT_LEVEL(Log::Debug, text, 0)
 #else
 #define DEBUG_LOG(text)
 #define DEBUG_LOG_NOLOCK(text)
 #endif
 
 /** Add a notice to the log */
-#define NOTICE(text) \
-  do \
-  { \
-    Log::instance().m_Lock.acquire(); \
-    FILE_LOG(Log::Notice); \
-    Log::instance() << Log::Notice << text << Flush; \
-    Log::instance().m_Lock.release(); \
-  } \
-  while (0)
-
-/// \note You use this in the wrong way, you die.
-#define NOTICE_NOLOCK(text) \
-  do \
-  { \
-    FILE_LOG(Log::Notice); \
-    Log::instance() << Log::Notice << text << Flush; \
-  } \
-  while (0)
+#define NOTICE(text) LOG_AT_LEVEL(Log::Notice, text, 1)
+#define NOTICE_NOLOCK(text) LOG_AT_LEVEL(Log::Notice, text, 0)
 
 /** Add a warning message to the log */
-#define WARNING(text) \
-  do \
-  { \
-    Log::instance().m_Lock.acquire(); \
-    FILE_LOG(Log::Warning); \
-    Log::instance() << Log::Warning << text << Flush; \
-    Log::instance().m_Lock.release(); \
-  } \
-  while (0)
-
-/// \note You use this in the wrong way, you die.
-#define WARNING_NOLOCK(text) \
-  do \
-  { \
-    FILE_LOG(Log::Warning); \
-    Log::instance() << Log::Warning << text << Flush; \
-  } \
-  while (0)
+#define WARNING(text) LOG_AT_LEVEL(Log::Warning, text, 1)
+#define WARNING_NOLOCK(text) LOG_AT_LEVEL(Log::Warning, text, 0)
 
 /** Add a error message to the log */
-#define ERROR(text) \
-  do \
-  { \
-    Log::instance().m_Lock.acquire(); \
-    FILE_LOG(Log::Error); \
-    Log::instance() << Log::Error << text << Flush; \
-    Log::instance().m_Lock.release(); \
-  } \
-  while (0)
-
-/// \note You use this in the wrong way, you die.
-#define ERROR_NOLOCK(text) \
-  do \
-  { \
-    FILE_LOG(Log::Error); \
-    Log::instance() << Log::Error << text << Flush; \
-  } \
-  while (0)
-
+#define ERROR(text) LOG_AT_LEVEL(Log::Error, text, 1)
+#define ERROR_NOLOCK(text) LOG_AT_LEVEL(Log::Error, text, 0)
 
 /** Add a fatal message to the log
- *  The panic is just in case the debugger isn't active, or the user returns
- *  from the debugger.
+ *  Breaks into debugger and panics if the debugger isn't around, or the user
+ *  exits it.
  */
-#define FATAL(text) \
-  do \
-  { \
-    Log::instance().m_Lock.acquire(); \
-    FILE_LOG(Log::Fatal); \
-    Log::instance() << Log::Fatal << text << Flush; \
-    const char *panicstr = static_cast<const char*>(Log::instance().getLatestEntry().str); \
-    Log::instance().m_Lock.release(); \
-    Processor::breakpoint(); \
-    panic(panicstr); \
-  } \
-  while (0)
+#define FATAL(text) do { LOG_AT_LEVEL(Log::Fatal, text, 1); while(1); } while(0)
+#define FATAL_NOLOCK(text) do { LOG_AT_LEVEL(Log::Fatal, text, 0); while(1); } while(0)
 
-/// \note You use this in the wrong way, you die.
-#define FATAL_NOLOCK(text) \
-  do \
-  { \
-    FILE_LOG(Log::Fatal); \
-    Log::instance() << Log::Fatal << text << Flush; \
-    Processor::breakpoint(); \
-    panic(static_cast<const char*>(Log::instance().getLatestEntry().str)); \
-  } \
-  while (0)
+#else  // NO_LOGGING
+
+#define DEBUG_LOG(text)
+#define DEBUG_LOG_NOLOCK(text)
+#define NOTICE(text)
+#define NOTICE_NOLOCK(text)
+#define WARNING(text)
+#define WARNING_NOLOCK(text)
+#define ERROR(text)
+#define ERROR_NOLOCK(text)
+#define FATAL(text)
+#define FATAL_NOLOCK(text)
+
+#endif
 
 /** The maximum length of an individual static log entry. */
 #define LOG_LENGTH  128

--- a/src/system/include/process/Process.h
+++ b/src/system/include/process/Process.h
@@ -20,6 +20,8 @@
 #ifndef PROCESS_H
 #define PROCESS_H
 
+#ifdef THREADS
+
 #include <compiler.h>
 #include <process/Thread.h>
 #include <processor/state.h>
@@ -498,5 +500,7 @@ private:
 public:
     Semaphore m_DeadThreads;
 };
+
+#endif
 
 #endif

--- a/src/system/include/processor/hosted/ProcessorInformation.h
+++ b/src/system/include/processor/hosted/ProcessorInformation.h
@@ -51,6 +51,7 @@ class HostedProcessorInformation
 
     inline uintptr_t getKernelStack() const;
     void setKernelStack(uintptr_t stack);
+#ifdef THREADS
     inline Thread *getCurrentThread() const
       {return m_pCurrentThread;}
     inline void setCurrentThread(Thread *pThread)
@@ -58,6 +59,7 @@ class HostedProcessorInformation
 
     inline PerProcessorScheduler &getScheduler()
       {return m_Scheduler;}
+#endif
 
   protected:
     /** Construct a HostedProcessorInformation object
@@ -65,7 +67,11 @@ class HostedProcessorInformation
     inline HostedProcessorInformation(ProcessorId processorId, uint8_t apicId = 0)
       : m_ProcessorId(processorId),
         m_VirtualAddressSpace(&VirtualAddressSpace::getKernelAddressSpace()),
-        m_pCurrentThread(0), m_Scheduler(), m_KernelStack(0) {}
+#ifdef THREADS
+        m_pCurrentThread(0),
+        m_Scheduler(),
+#endif
+        m_KernelStack(0) {}
     /** The destructor does nothing */
     inline virtual ~HostedProcessorInformation(){}
 
@@ -84,10 +90,12 @@ class HostedProcessorInformation
     ProcessorId m_ProcessorId;
     /** The current VirtualAddressSpace */
     VirtualAddressSpace *m_VirtualAddressSpace;
+#ifdef THREADS
     /** The current thread */
     Thread *m_pCurrentThread;
     /** The processor's scheduler. */
     PerProcessorScheduler m_Scheduler;
+#endif
     /** Kernel stack. */
     uintptr_t m_KernelStack;
 };

--- a/src/system/include/utilities/Cache.h
+++ b/src/system/include/utilities/Cache.h
@@ -32,6 +32,8 @@
 #include <processor/PhysicalMemoryManager.h>
 #include <process/MemoryPressureManager.h>
 
+#include <utilities/CacheConstants.h>
+
 /// The age at which a cache page is considered "old" and can be evicted
 /// This is expressed in seconds.
 #define CACHE_AGE_THRESHOLD 10
@@ -128,22 +130,6 @@ private:
     };
 
 public:
-
-    /**
-     * Callback Cause enumeration.
-     *
-     * Callbacks can be called for a number of reasons. Instead of having
-     * a callback for each reason, we just offer this enumeration. Callbacks
-     * can then do a switch on this in order to select which behaviour to
-     * invoke.
-     */
-    enum CallbackCause
-    {
-        WriteBack,
-        Eviction,
-        PleaseEvict,
-    };
-
     /**
      * Callback type: for functions called by the write-back timer handler.
      *
@@ -154,7 +140,7 @@ public:
      *
      * Then, the write-back thread will mark the page as not-dirty.
      */
-    typedef void (*writeback_t)(CallbackCause cause, uintptr_t loc, uintptr_t page, void *meta);
+    typedef void (*writeback_t)(CacheConstants::CallbackCause cause, uintptr_t loc, uintptr_t page, void *meta);
 
     Cache();
     virtual ~Cache();
@@ -306,7 +292,7 @@ private:
 
     struct callbackMeta
     {
-        CallbackCause cause;
+        CacheConstants::CallbackCause cause;
         writeback_t callback;
         uintptr_t loc;
         uintptr_t page;

--- a/src/system/include/utilities/CacheConstants.h
+++ b/src/system/include/utilities/CacheConstants.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2014, Pedigree Developers
+ *
+ * Please see the CONTRIB file in the root of the source tree for a full
+ * list of contributors.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef CACHE_CONSTANTS_H
+#define CACHE_CONSTANTS_H
+
+// Provides constants for Cache without needing to include the entire Cache
+// class, which may not be necessary in all situations.
+namespace CacheConstants
+{
+
+/**
+ * Callback Cause enumeration.
+ *
+ * Callbacks can be called for a number of reasons. Instead of having
+ * a callback for each reason, we just offer this enumeration. Callbacks
+ * can then do a switch on this in order to select which behaviour to
+ * invoke.
+ */
+enum CallbackCause
+{
+    WriteBack,
+    Eviction,
+    PleaseEvict,
+};
+
+}
+
+#endif  // CACHE_CONSTANTS_H

--- a/src/system/include/utilities/RadixTree.h
+++ b/src/system/include/utilities/RadixTree.h
@@ -25,7 +25,6 @@
 #include <utilities/Iterator.h>
 #include <utilities/IteratorAdapter.h>
 #include <Log.h>
-#include <processor/Processor.h>
 
 /**\file  RadixTree.h
  *\author James Molloy <jamesm@osdev.org>

--- a/src/system/include/utilities/Tree.h
+++ b/src/system/include/utilities/Tree.h
@@ -25,7 +25,7 @@
 
 #include <Log.h>
 
-#include <new>
+#include <utilities/new>
 
 /** @addtogroup kernelutilities
  * @{ */

--- a/src/system/include/utilities/new
+++ b/src/system/include/utilities/new
@@ -16,6 +16,9 @@
 #ifndef _NEW_H
 #define _NEW_H
 
+// If UTILITY_LINUX is set, we're working on Linux and so already have <new>.
+#ifndef UTILITY_LINUX
+
 #include <compiler.h>
 #include <processor/types.h>
 
@@ -30,5 +33,7 @@ void* operator new(size_t, void* p) throw();
 void* operator new[](size_t, void* p) throw();
 void  operator delete  (void*, void*) throw() NORETURN;
 void  operator delete[](void*, void*) throw() NORETURN;
+
+#endif  // UTILITY_LINUX
 
 #endif

--- a/src/system/include/utilities/utility.h
+++ b/src/system/include/utilities/utility.h
@@ -91,13 +91,10 @@ extern "C" {
 
 #endif
 
-int vsprintf(char *buf, const char *fmt, va_list arg);
-int sprintf(char *buf, const char *fmt, ...);
 size_t strlen(const char *buf);
 int strcpy(char *dest, const char *src);
 int strncpy(char *dest, const char *src, int len);
 void *memset(void *buf, int c, size_t len);
-void *wmemset(void *buf, int c, size_t len);
 void *dmemset(void *buf, unsigned int c, size_t len);
 void *qmemset(void *buf, unsigned long long c, size_t len);
 void *memcpy(void *s1, const void *s2, size_t n);
@@ -114,6 +111,17 @@ uint64_t random_next();
 
 const char *strchr(const char *str, int target);
 const char *strrchr(const char *str, int target);
+
+#ifdef UTILITY_LINUX
+#include <stdio.h>
+#else
+// When using parts of the kernel for tools to run on build systems, we can run
+// into conflicts with some of our functions. So, we only define them if we are
+// not building for build systems.
+void *wmemset(void *buf, int c, size_t len);
+int vsprintf(char *buf, const char *fmt, va_list arg);
+int sprintf(char *buf, const char *fmt, ...);
+#endif
 
 /**
  * Custom API that differs from the standard strtoul and therefore conflicts.

--- a/src/system/kernel/Log.cc
+++ b/src/system/kernel/Log.cc
@@ -72,7 +72,9 @@ static NormalStaticString getTimestamp()
 }
 
 Log::Log () :
+#ifdef THREADS
     m_Lock(),
+#endif
     m_StaticEntries(0),
     m_StaticEntryStart(0),
     m_StaticEntryEnd(0),
@@ -127,7 +129,9 @@ void Log::initialise2()
 void Log::installCallback(LogCallback *pCallback, bool bSkipBacklog)
 {
     {
+#ifdef THREADS
         LockGuard<Spinlock> guard(m_Lock);
+#endif
         m_OutputCallbacks.pushBack(pCallback);
     }
 
@@ -184,7 +188,9 @@ void Log::installCallback(LogCallback *pCallback, bool bSkipBacklog)
 }
 void Log::removeCallback(LogCallback *pCallback)
 {
+#ifdef THREADS
     LockGuard<Spinlock> guard(m_Lock);
+#endif
     for(List<LogCallback*>::Iterator it = m_OutputCallbacks.begin();
         it != m_OutputCallbacks.end();
         it++)
@@ -318,8 +324,10 @@ Log &Log::operator<< (Modifier type)
             handlingFatal = true;
 
             const char *panicstr = static_cast<const char*>(m_Buffer.str);
+#ifdef THREADS
             if (m_Lock.acquired())
                 m_Lock.release();
+#endif
 
             // Attempt to trap to debugger, panic if that fails.
 #ifdef DEBUGGER

--- a/src/system/kernel/Log.cc
+++ b/src/system/kernel/Log.cc
@@ -352,6 +352,7 @@ Log &Log::operator<< (SeverityLevel level)
     m_Buffer.str.clear();
     m_Buffer.type = level;
 
+#ifndef UTILITY_LINUX
     Machine &machine = Machine::instance();
     if (machine.isInitialised() == true &&
         machine.getTimer() != 0)
@@ -361,6 +362,7 @@ Log &Log::operator<< (SeverityLevel level)
     }
     else
         m_Buffer.timestamp = 0;
+#endif
 
     return *this;
 }

--- a/src/system/kernel/SConscript
+++ b/src/system/kernel/SConscript
@@ -40,6 +40,7 @@ files = [
     'Subsystem.cc',
     'ServiceManager.cc',
     'Service.cc',
+    'syscallError.cc',
     Glob('utilities/*.cc'),
     Glob('utilities/sha1/*.cc'),
     Glob('utilities/md5/*.cc'),

--- a/src/system/kernel/machine/Device.cc
+++ b/src/system/kernel/machine/Device.cc
@@ -209,6 +209,7 @@ Device::Address::Address(String n, uintptr_t a, size_t s, bool io, size_t pad) :
   m_Name(n), m_Address(a), m_Size(s), m_IsIoSpace(io), m_Io(0), m_Padding(pad),
   m_bMapped(false)
 {
+#ifndef DEVICE_IGNORE_ADDRESSES
 #ifndef KERNEL_PROCESSOR_NO_PORT_IO
     if (m_IsIoSpace)
     {
@@ -229,10 +230,12 @@ Device::Address::Address(String n, uintptr_t a, size_t s, bool io, size_t pad) :
 #ifndef KERNEL_PROCESSOR_NO_PORT_IO
     }
 #endif
+#endif  // DEVICE_IGNORE_ADDRESSES
 }
 
 void Device::Address::map(size_t forcedSize, bool bUser, bool bWriteCombine, bool bWriteThrough)
 {
+#ifndef DEVICE_IGNORE_ADDRESSES
     if(!m_Io)
         return;
 #ifndef KERNEL_PROCESSOR_NO_PORT_IO
@@ -270,10 +273,13 @@ void Device::Address::map(size_t forcedSize, bool bUser, bool bWriteCombine, boo
     NOTICE("Device::Address: mapped " << m_Address << " -> " << reinterpret_cast<uintptr_t>(static_cast<MemoryMappedIo*>(m_Io)->virtualAddress()));
 
     m_bMapped = true;
+#endif  // DEVICE_IGNORE_ADDRESSES
 }
 
 Device::Address::~Address()
 {
+#ifndef DEVICE_IGNORE_ADDRESSES
   if (m_Io)
     delete m_Io;
+#endif
 }

--- a/src/system/kernel/syscallError.cc
+++ b/src/system/kernel/syscallError.cc
@@ -17,14 +17,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifndef SYSCALL_ERROR_H
-#define SYSCALL_ERROR_H
+#include <syscallError.h>
+#include <process/Thread.h>
+#include <processor/Processor.h>
 
-#include <errors.h>
-
-// For setting a thread's error number when a problem occurs in a syscall.
-void syscallError(int e);
-
-#define SYSCALL_ERROR(x) syscallError(Error::x)
-
-#endif
+void syscallError(int errno)
+{
+    Processor::information().getCurrentThread()->setErrno(errno);
+}


### PR DESCRIPTION
The custom tool can use the existing VFS and ext2 code to do its work, which will also help with longer-term testing of these code paths.

This must allow for inserting files to ext2 partitions that are within an already-partitioned image.
